### PR TITLE
ci: atualizar Actions para runtime Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -55,13 +55,13 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: false


### PR DESCRIPTION
Closes #6

## O que muda

- atualiza `actions/checkout` para v7.0.1
- atualiza `actions/setup-node` para v7.0.0
- atualiza `docker/setup-buildx-action` para v4.2.0
- atualiza `docker/build-push-action` para v7.3.0
- mantém todas as Actions fixadas por SHA completo
- preserva permissões mínimas e a matriz Node 20/22 do projeto

As quatro versões declaram `using: node24`, eliminando os avisos de runtime Node.js 20 obsoleto.

## Validação local

- `npm run format:check`
- YAML do workflow validado
- `git diff --check`