### PR TITLE
test: ampliar cobertura dos handlers Kommo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - `.editorconfig`, configuração de ESLint e Prettier.
 - Arquivo `.dockerignore`.
 - Testes de integração do lifecycle, sessões, autenticação, Origin e schemas.
+- Testes unitários dos handlers de leitura e escrita com cliente Kommo simulado.
 - Validação JSON Schema dos argumentos de todas as tools.
 - Expiração e encerramento explícito de sessões MCP.
 - `ROADMAP.md` e `MAINTAINERS.md`.

--- a/test/tool-handlers.test.mjs
+++ b/test/tool-handlers.test.mjs
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { executeTool } from '../dist/mcp/tool-handlers.js';
+
+function resultData(result) {
+  assert.equal(result.isError, undefined);
+  assert.equal(result.content.length, 1);
+  return JSON.parse(result.content[0].text);
+}
+
+test('get_lead delegates the requested ID and serializes the response', async () => {
+  const calls = [];
+  const api = {
+    async getLead(id) {
+      calls.push(id);
+      return { id, name: 'Lead de teste' };
+    },
+  };
+
+  const result = await executeTool(api, 'get_lead', { id: 42 });
+
+  assert.deepEqual(calls, [42]);
+  assert.deepEqual(resultData(result), { id: 42, name: 'Lead de teste' });
+});
+
+test('get_leads applies pagination defaults and preserves the query', async () => {
+  const calls = [];
+  const api = {
+    async getLeads(params) {
+      calls.push(params);
+      return { _embedded: { leads: [] } };
+    },
+  };
+
+  await executeTool(api, 'get_leads', { query: 'Maria' });
+
+  assert.deepEqual(calls, [{ limit: 250, page: 1, query: 'Maria' }]);
+});
+
+test('create_lead forwards only the supplied payload', async () => {
+  const calls = [];
+  const payload = { name: 'Novo lead', price: 1500, pipeline_id: 7 };
+  const api = {
+    async createLead(input) {
+      calls.push(input);
+      return { id: 101, ...input };
+    },
+  };
+
+  const result = await executeTool(api, 'create_lead', payload);
+
+  assert.deepEqual(calls, [payload]);
+  assert.deepEqual(resultData(result), { id: 101, ...payload });
+});
+
+test('move_lead selects the pipeline operation when pipeline_id is present', async () => {
+  const calls = [];
+  const api = {
+    async moveLeadToPipeline(leadId, pipelineId, statusId) {
+      calls.push({ leadId, pipelineId, statusId });
+      return { id: leadId, pipeline_id: pipelineId, status_id: statusId };
+    },
+  };
+
+  const result = await executeTool(api, 'move_lead', {
+    lead_id: 12,
+    pipeline_id: 3,
+    status_id: 8,
+  });
+
+  assert.deepEqual(calls, [{ leadId: 12, pipelineId: 3, statusId: 8 }]);
+  assert.deepEqual(resultData(result), { id: 12, pipeline_id: 3, status_id: 8 });
+});
+
+test('invalid handler arguments return an MCP tool error without calling Kommo', async () => {
+  const api = {
+    async getLead() {
+      assert.fail('Kommo must not be called for invalid arguments');
+    },
+  };
+
+  const result = await executeTool(api, 'get_lead', { id: 'invalid' });
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /id/);
+});
+
+test('Kommo API failures are propagated to the transport error boundary', async () => {
+  const apiError = new Error('Kommo unavailable');
+  const api = {
+    async createLead() {
+      throw apiError;
+    },
+  };
+
+  await assert.rejects(() => executeTool(api, 'create_lead', { name: 'Teste' }), apiError);
+});


### PR DESCRIPTION
Closes #3

## O que muda

Adiciona testes unitários dos handlers MCP usando um cliente Kommo inteiramente simulado, sem rede, tokens ou dados reais.

### Cenários cobertos

- leitura de lead e serialização da resposta
- paginação padrão e filtro em `get_leads`
- criação de lead e payload encaminhado
- movimentação de lead entre pipeline/status
- argumentos inválidos sem chamada à Kommo
- propagação de falhas da API para a fronteira do transporte

A suíte passa de 6 para 12 testes.

## Validação

- `npm run typecheck`
- `npm run lint`
- `npm test` — 12/12
- `npm run format:check`
- `npm run audit:prod` — 0 vulnerabilidades
- `git diff --check`