### PR TITLE
refactor: tipar payloads da API Kommo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,8 +21,7 @@ module.exports = {
       'warn',
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
-    // The Kommo API exposes heterogeneous payloads. Tighten these types incrementally.
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
     'no-console': 'off',
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - Dependências de produção atualizadas e vulnerabilidades conhecidas corrigidas.
 - CI passa a reprovar lint/formatação, executar testes e auditar dependências.
 - Servidor exige autenticação quando exposto fora de interfaces loopback.
+- Tipos da API Kommo e da análise conversacional agora são explícitos; o lint
+  volta a proibir `any` em todo código-fonte.
 
 ### Removido
 

--- a/src/ask-kommo.ts
+++ b/src/ask-kommo.ts
@@ -1,10 +1,10 @@
-import { KommoAPI } from './kommo-api.js';
+import { KommoAPI, type KommoLead } from './kommo-api.js';
 import type { McpToolResult } from './mcp/types.js';
 
 const currentYear = new Date().getFullYear();
 
 interface CacheEntry {
-  data: unknown[];
+  data: KommoLead[];
   timestamp: number;
   expiresAt: number;
 }
@@ -23,13 +23,13 @@ function isCacheValid(): boolean {
   return Date.now() < leadsCache.expiresAt && leadsCache.data.length > 0;
 }
 
-function setCacheData(data: unknown[]): void {
+function setCacheData(data: KommoLead[]): void {
   leadsCache.data = data;
   leadsCache.timestamp = Date.now();
   leadsCache.expiresAt = Date.now() + CACHE_DURATION;
 }
 
-function getCacheData(): unknown[] {
+function getCacheData(): KommoLead[] {
   return leadsCache.data;
 }
 
@@ -260,10 +260,10 @@ const monthNames = [
 ];
 
 function filterLeadsByPeriod(
-  leads: any[],
+  leads: KommoLead[],
   temporalFilter: string | null,
   month: number | null,
-): any[] {
+): KommoLead[] {
   let filtered = leads;
   if (temporalFilter) {
     const { start, end } = getDateRange(temporalFilter);
@@ -285,10 +285,10 @@ export async function handleAskKommo(kommoAPI: KommoAPI, question: string): Prom
   const startTime = Date.now();
   const questionLower = question.toLowerCase();
 
-  let leadsArray: any[];
+  let leadsArray: KommoLead[];
   const isCacheHit = isCacheValid();
   if (isCacheHit) {
-    leadsArray = getCacheData() as any[];
+    leadsArray = getCacheData();
   } else {
     leadsArray = await kommoAPI.getAllLeads();
     setCacheData(leadsArray);
@@ -309,7 +309,7 @@ export async function handleAskKommo(kommoAPI: KommoAPI, question: string): Prom
     questionLower.includes('fechado') ||
     questionLower.includes('ganho')
   ) {
-    let salesLeads = leadsArray.filter((lead: any) => {
+    let salesLeads = leadsArray.filter((lead) => {
       const status = lead.status?.toString().toLowerCase() || '';
       const isClosedStatus =
         status.includes('fechado') || status.includes('ganho') || status.includes('concluído');
@@ -318,20 +318,18 @@ export async function handleAskKommo(kommoAPI: KommoAPI, question: string): Prom
 
     if (temporalFilter) {
       const { start, end } = getDateRange(temporalFilter);
-      salesLeads = salesLeads.filter((lead: any) => {
+      salesLeads = salesLeads.filter((lead) => {
         const updatedAt = new Date(lead.updated_at * 1000);
         return updatedAt >= start && updatedAt <= end;
       });
     }
 
     if (category) {
-      salesLeads = salesLeads.filter((lead: any) =>
-        (lead.name || '').toLowerCase().includes(category),
-      );
+      salesLeads = salesLeads.filter((lead) => (lead.name || '').toLowerCase().includes(category));
     }
 
     const totalSales = salesLeads.length;
-    const totalValue = salesLeads.reduce((sum: number, lead: any) => sum + (lead.price || 0), 0);
+    const totalValue = salesLeads.reduce((sum, lead) => sum + (lead.price || 0), 0);
     const averageTicket = totalSales > 0 ? totalValue / totalSales : 0;
 
     response = `💰 **Análise de Vendas**\n\n`;
@@ -350,12 +348,12 @@ export async function handleAskKommo(kommoAPI: KommoAPI, question: string): Prom
     const filteredLeads = filterLeadsByPeriod(leadsArray, temporalFilter, month);
     const contacts = await kommoAPI.getContacts({ limit: 250 });
     const contactsArray = contacts._embedded?.contacts || [];
-    const leadsWithContactInfo = filteredLeads.filter((lead: any) =>
+    const leadsWithContactInfo = filteredLeads.filter((lead) =>
       contactsArray.some(
-        (c: any) =>
-          c.name &&
+        (contact) =>
+          contact.name &&
           lead.name &&
-          c.name.toLowerCase().includes(lead.name.toLowerCase().split(' ')[0]),
+          contact.name.toLowerCase().includes(lead.name.toLowerCase().split(' ')[0]),
       ),
     );
 
@@ -367,13 +365,13 @@ export async function handleAskKommo(kommoAPI: KommoAPI, question: string): Prom
   } else if (questionLower.includes('lead') || questionLower.includes('leads')) {
     let filteredLeads = filterLeadsByPeriod(leadsArray, temporalFilter, month);
     if (category) {
-      filteredLeads = filteredLeads.filter((lead: any) =>
+      filteredLeads = filteredLeads.filter((lead) =>
         (lead.name || '').toLowerCase().includes(category),
       );
     }
 
     const totalLeads = filteredLeads.length;
-    const totalValue = filteredLeads.reduce((sum: number, lead: any) => sum + (lead.price || 0), 0);
+    const totalValue = filteredLeads.reduce((sum, lead) => sum + (lead.price || 0), 0);
 
     response = `📋 **Análise de Leads**\n\n`;
     response += `📊 **Total de leads:** ${totalLeads}\n`;
@@ -394,7 +392,7 @@ export async function handleAskKommo(kommoAPI: KommoAPI, question: string): Prom
     suggestions.push('"Quantas vendas tivemos este mês?"');
   } else {
     const totalLeads = leadsArray.length;
-    const totalValue = leadsArray.reduce((sum: number, lead: any) => sum + (lead.price || 0), 0);
+    const totalValue = leadsArray.reduce((sum, lead) => sum + (lead.price || 0), 0);
     response = `🤔 Entendi sua mensagem: "${question}"\n\n`;
     response += `📊 **Resumo geral:**\n`;
     response += `• Total de leads: ${totalLeads}\n`;

--- a/src/kommo-api.ts
+++ b/src/kommo-api.ts
@@ -5,6 +5,34 @@ export interface KommoConfig {
   accessToken: string;
 }
 
+export type KommoQueryParams = Record<string, string | number | boolean | undefined>;
+
+export interface KommoCustomFieldValue {
+  field_id?: number;
+  field_name?: string;
+  field_code?: string;
+  values?: Array<Record<string, unknown>>;
+}
+
+export interface KommoAccount {
+  id: number;
+  name: string;
+  subdomain: string;
+  country?: string;
+  currency?: string;
+  timezone?: string;
+  [key: string]: unknown;
+}
+
+export interface KommoUser {
+  id: number;
+  name: string;
+  email?: string;
+  language?: string;
+  rights?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 export interface KommoLead {
   id: number;
   name: string;
@@ -18,6 +46,7 @@ export interface KommoLead {
   closed_at?: number;
   loss_reason_id?: number;
   source_id?: number;
+  status?: string | number;
   tags?: string[];
   contacts?: KommoContact[];
   companies?: KommoCompany[];
@@ -32,7 +61,7 @@ export interface KommoContact {
   created_by: number;
   created_at: number;
   updated_at: number;
-  custom_fields_values?: any[];
+  custom_fields_values?: KommoCustomFieldValue[];
   tags?: string[];
   leads?: KommoLead[];
   companies?: KommoCompany[];
@@ -45,7 +74,7 @@ export interface KommoCompany {
   created_by: number;
   created_at: number;
   updated_at: number;
-  custom_fields_values?: any[];
+  custom_fields_values?: KommoCustomFieldValue[];
   tags?: string[];
   leads?: KommoLead[];
   contacts?: KommoContact[];
@@ -92,7 +121,7 @@ export interface KommoEvent {
   created_by: number;
   responsible_user_id: number;
   text?: string;
-  data?: any;
+  data?: unknown;
 }
 
 export interface KommoActivity {
@@ -105,7 +134,7 @@ export interface KommoActivity {
   created_by: number;
   responsible_user_id: number;
   text?: string;
-  data?: any;
+  data?: unknown;
 }
 
 // Novas interfaces para Status
@@ -214,18 +243,18 @@ export class KommoAPI {
   }
 
   // Account methods
-  async getAccount(): Promise<any> {
+  async getAccount(): Promise<KommoAccount> {
     const response = await this.client.get('/api/v4/account');
     return response.data;
   }
 
   // Leads methods
-  async getLeads(params?: any): Promise<{ _embedded: { leads: KommoLead[] } }> {
+  async getLeads(params?: KommoQueryParams): Promise<{ _embedded: { leads: KommoLead[] } }> {
     const response = await this.client.get('/api/v4/leads', { params });
     return response.data;
   }
 
-  async getAllLeads(params?: any): Promise<KommoLead[]> {
+  async getAllLeads(params?: KommoQueryParams): Promise<KommoLead[]> {
     const allLeads: KommoLead[] = [];
     let page = 1;
     let hasMore = true;
@@ -298,7 +327,9 @@ export class KommoAPI {
   }
 
   // Contacts methods
-  async getContacts(params?: any): Promise<{ _embedded: { contacts: KommoContact[] } }> {
+  async getContacts(
+    params?: KommoQueryParams,
+  ): Promise<{ _embedded: { contacts: KommoContact[] } }> {
     const response = await this.client.get('/api/v4/contacts', { params });
     return response.data;
   }
@@ -319,7 +350,9 @@ export class KommoAPI {
   }
 
   // Companies methods
-  async getCompanies(params?: any): Promise<{ _embedded: { companies: KommoCompany[] } }> {
+  async getCompanies(
+    params?: KommoQueryParams,
+  ): Promise<{ _embedded: { companies: KommoCompany[] } }> {
     const response = await this.client.get('/api/v4/companies', { params });
     return response.data;
   }
@@ -351,7 +384,7 @@ export class KommoAPI {
   }
 
   // Tasks methods
-  async getTasks(params?: any): Promise<{ _embedded: { tasks: KommoTask[] } }> {
+  async getTasks(params?: KommoQueryParams): Promise<{ _embedded: { tasks: KommoTask[] } }> {
     const response = await this.client.get('/api/v4/tasks', { params });
     return response.data;
   }
@@ -372,12 +405,12 @@ export class KommoAPI {
   }
 
   // Users methods
-  async getUsers(): Promise<{ _embedded: { users: any[] } }> {
+  async getUsers(): Promise<{ _embedded: { users: KommoUser[] } }> {
     const response = await this.client.get('/api/v4/users');
     return response.data;
   }
 
-  async getUser(id: number): Promise<any> {
+  async getUser(id: number): Promise<KommoUser> {
     const response = await this.client.get(`/api/v4/users/${id}`);
     return response.data;
   }
@@ -387,7 +420,7 @@ export class KommoAPI {
   // Eventos de leads
   async getLeadEvents(
     leadId: number,
-    params?: any,
+    params?: KommoQueryParams,
   ): Promise<{ _embedded: { events: KommoEvent[] } }> {
     const response = await this.client.get(`/api/v4/leads/${leadId}/events`, { params });
     return response.data;
@@ -413,7 +446,7 @@ export class KommoAPI {
   // Atividades de contatos
   async getContactActivities(
     contactId: number,
-    params?: any,
+    params?: KommoQueryParams,
   ): Promise<{ _embedded: { activities: KommoActivity[] } }> {
     const response = await this.client.get(`/api/v4/contacts/${contactId}/activities`, { params });
     return response.data;
@@ -478,7 +511,9 @@ export class KommoAPI {
     pipelineId: number,
     statusId?: number,
   ): Promise<KommoLead> {
-    const updateData: any = { pipeline_id: pipelineId };
+    const updateData: Pick<KommoLead, 'pipeline_id'> & Partial<Pick<KommoLead, 'status_id'>> = {
+      pipeline_id: pipelineId,
+    };
     if (statusId) {
       updateData.status_id = statusId;
     }
@@ -500,7 +535,10 @@ export class KommoAPI {
     return response.data;
   }
 
-  async getLeadConversionReport(dateFrom: string, dateTo: string): Promise<any> {
+  async getLeadConversionReport(
+    dateFrom: string,
+    dateTo: string,
+  ): Promise<Record<string, unknown>> {
     const response = await this.client.get('/api/v4/leads/reports', {
       params: {
         date_from: dateFrom,
@@ -511,7 +549,10 @@ export class KommoAPI {
     return response.data;
   }
 
-  async getPipelinePerformanceReport(dateFrom: string, dateTo: string): Promise<any> {
+  async getPipelinePerformanceReport(
+    dateFrom: string,
+    dateTo: string,
+  ): Promise<Record<string, unknown>> {
     const response = await this.client.get('/api/v4/leads/pipelines/reports', {
       params: {
         date_from: dateFrom,
@@ -527,8 +568,12 @@ export class KommoAPI {
     return response.data;
   }
 
-  async getUserPerformanceStats(userId: number, dateFrom?: string, dateTo?: string): Promise<any> {
-    const params: any = {};
+  async getUserPerformanceStats(
+    userId: number,
+    dateFrom?: string,
+    dateTo?: string,
+  ): Promise<Record<string, unknown>> {
+    const params: KommoQueryParams = {};
     if (dateFrom) params.date_from = dateFrom;
     if (dateTo) params.date_to = dateTo;
 
@@ -537,13 +582,17 @@ export class KommoAPI {
   }
 
   // Analytics avançados
-  async getLeadAnalytics(leadId: number): Promise<any> {
+  async getLeadAnalytics(leadId: number): Promise<Record<string, unknown>> {
     const response = await this.client.get(`/api/v4/leads/${leadId}/analytics`);
     return response.data;
   }
 
-  async getPipelineAnalytics(pipelineId: number, dateFrom?: string, dateTo?: string): Promise<any> {
-    const params: any = {};
+  async getPipelineAnalytics(
+    pipelineId: number,
+    dateFrom?: string,
+    dateTo?: string,
+  ): Promise<Record<string, unknown>> {
+    const params: KommoQueryParams = {};
     if (dateFrom) params.date_from = dateFrom;
     if (dateTo) params.date_to = dateTo;
 
@@ -586,13 +635,13 @@ export class KommoAPI {
   async runSalesbot(params: {
     entity_id: number;
     entity_type: string;
-    [key: string]: any;
-  }): Promise<any> {
+    [key: string]: unknown;
+  }): Promise<unknown> {
     const response = await this.client.post('/api/v4/bots/run', params);
     return response.data;
   }
 
-  async stopSalesbot(botId: number): Promise<any> {
+  async stopSalesbot(botId: number): Promise<unknown> {
     const response = await this.client.post(`/api/v4/bots/${botId}/stop`);
     return response.data;
   }


### PR DESCRIPTION
Closes #5

## O que muda

Remove todos os usos explícitos de `any` do código-fonte sem alterar o comportamento público das tools.

### Tipos adicionados ou fortalecidos

- `KommoAccount` e `KommoUser`
- campos customizados de contatos e empresas
- parâmetros de consulta reutilizáveis
- dados de eventos e atividades como `unknown`
- respostas de analytics e relatórios como registros desconhecidos
- payloads e resultados do Salesbot
- cache e filtros de `ask_kommo` tipados com `KommoLead`
- payload de movimentação entre pipeline/status

O ESLint volta a tratar `@typescript-eslint/no-explicit-any` como erro, impedindo regressões.

## Compatibilidade

A mudança é somente de tipos e manutenção interna; nomes, schemas e respostas das tools permanecem iguais.

## Validação

- `npm run typecheck`
- `npm run lint`
- `npm test` — 12/12
- `npm run format:check`
- `npm run audit:prod` — 0 vulnerabilidades
- busca por `any` em `src/` — zero ocorrências
- `git diff --check`