### PR TITLE
fix: garantir compatibilidade com cliente MCP oficial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - Arquivo `.dockerignore`.
 - Testes de integração do lifecycle, sessões, autenticação, Origin e schemas.
 - Testes unitários dos handlers de leitura e escrita com cliente Kommo simulado.
+- Teste de conformidade ponta a ponta com o cliente MCP TypeScript oficial.
 - Validação JSON Schema dos argumentos de todas as tools.
 - Expiração e encerramento explícito de sessões MCP.
 - `ROADMAP.md` e `MAINTAINERS.md`.
@@ -34,6 +35,8 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - Servidor exige autenticação quando exposto fora de interfaces loopback.
 - Tipos da API Kommo e da análise conversacional agora são explícitos; o lint
   volta a proibir `any` em todo código-fonte.
+- Negociação compatível com as revisões MCP legadas até `2025-11-25` e
+  instruções atuais para conectores remotos do Claude Desktop.
 
 ### Removido
 

--- a/README.md
+++ b/README.md
@@ -143,19 +143,13 @@ Adicione ao arquivo `~/.cursor/mcp.json` (ou nas configurações do projeto em
 
 ### Claude Desktop
 
-Adicione ao `claude_desktop_config.json`:
+Para uma implantação remota com HTTPS, abra **Settings → Connectors → Add
+connector** e informe a URL pública do endpoint, por exemplo
+`https://mcp.seudominio.com/mcp`.
 
-```json
-{
-  "mcpServers": {
-    "kommo": {
-      "url": "http://127.0.0.1:3001/mcp"
-    }
-  }
-}
-```
-
-Reinicie o cliente após alterar a configuração.
+O Claude Desktop não conecta servidores HTTP remotos configurados diretamente
+em `claude_desktop_config.json`. Esse arquivo é destinado a servidores locais
+executados como processos; o Kommo MCP oferece atualmente transporte HTTP.
 
 ## Endpoints
 
@@ -335,14 +329,14 @@ curl -X POST http://localhost:3001/mcp \
 
 ## Compatibilidade e suporte
 
-| Componente     | Suporte atual                          |
-| -------------- | -------------------------------------- |
-| Node.js        | 20 e 22                                |
-| Protocolo MCP  | `2025-06-18`                           |
-| Transporte     | Streamable HTTP, resposta JSON ou SSE  |
-| Cursor         | Configuração HTTP documentada          |
-| Claude Desktop | Configuração HTTP documentada          |
-| Instalação     | Git/Docker; ainda não publicado no npm |
+| Componente     | Suporte atual                                   |
+| -------------- | ----------------------------------------------- |
+| Node.js        | 20 e 22                                         |
+| Protocolo MCP  | revisões legadas de `2024-11-05` a `2025-11-25` |
+| Transporte     | Streamable HTTP, resposta JSON ou SSE           |
+| Cursor         | Configuração HTTP documentada                   |
+| Claude Desktop | Conector remoto via Settings → Connectors       |
+| Instalação     | Git/Docker; ainda não publicado no npm          |
 
 Suporte comunitário ocorre por Issues e Discussions, sem garantia de tempo de
 resposta. Veja as responsabilidades em [MAINTAINERS.md](MAINTAINERS.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^5.2.1"
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/node": "^20.0.0",
@@ -240,6 +241,38 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@noble/hashes": {
@@ -1498,6 +1531,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -2177,6 +2233,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
@@ -2581,6 +2647,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -3340,6 +3416,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "express": "^5.2.1"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^20.0.0",

--- a/src/http-streamable.ts
+++ b/src/http-streamable.ts
@@ -12,12 +12,19 @@ import { validateToolArguments } from './mcp/tool-validation.js';
 
 dotenv.config();
 
-const MCP_PROTOCOL_VERSION = '2025-06-18';
+const DEFAULT_MCP_PROTOCOL_VERSION = '2025-11-25';
+const SUPPORTED_MCP_PROTOCOL_VERSIONS = [
+  '2024-11-05',
+  '2025-03-26',
+  '2025-06-18',
+  '2025-11-25',
+] as const;
 const SESSION_TTL_MS = 60 * 60 * 1000;
 
 interface Session {
   initialized: boolean;
   lastSeenAt: number;
+  protocolVersion: string;
 }
 interface AppOptions {
   kommoAPI?: KommoAPI;
@@ -198,16 +205,26 @@ export function createApp(options: AppOptions = {}) {
     logger.debug('MCP request', { method, id });
 
     if (method === 'initialize') {
-      if (params?.protocolVersion !== MCP_PROTOCOL_VERSION) {
+      const requestedVersion = params?.protocolVersion;
+      if (
+        typeof requestedVersion !== 'string' ||
+        !SUPPORTED_MCP_PROTOCOL_VERSIONS.includes(
+          requestedVersion as (typeof SUPPORTED_MCP_PROTOCOL_VERSIONS)[number],
+        )
+      ) {
         res.status(400).json(
           jsonRpcError(id, -32602, 'Unsupported protocol version', {
-            supported: [MCP_PROTOCOL_VERSION],
+            supported: SUPPORTED_MCP_PROTOCOL_VERSIONS,
           }),
         );
         return;
       }
       const sessionId = crypto.randomUUID();
-      sessions.set(sessionId, { initialized: false, lastSeenAt: Date.now() });
+      sessions.set(sessionId, {
+        initialized: false,
+        lastSeenAt: Date.now(),
+        protocolVersion: requestedVersion,
+      });
       res.setHeader('MCP-Session-Id', sessionId);
       sendMcpResponse(
         res,
@@ -215,7 +232,7 @@ export function createApp(options: AppOptions = {}) {
           jsonrpc: '2.0',
           id,
           result: {
-            protocolVersion: MCP_PROTOCOL_VERSION,
+            protocolVersion: requestedVersion,
             capabilities: {
               tools: { listChanged: false },
               resources: { subscribe: false, listChanged: false },
@@ -233,16 +250,16 @@ export function createApp(options: AppOptions = {}) {
       return;
     }
 
-    if (req.header('MCP-Protocol-Version') !== MCP_PROTOCOL_VERSION) {
+    const session = requireSession(req, res);
+    if (!session) return;
+    if (req.header('MCP-Protocol-Version') !== session.protocolVersion) {
       res.status(400).json(
         jsonRpcError(id, -32600, 'Missing or unsupported MCP-Protocol-Version header', {
-          supported: [MCP_PROTOCOL_VERSION],
+          supported: SUPPORTED_MCP_PROTOCOL_VERSIONS,
         }),
       );
       return;
     }
-    const session = requireSession(req, res);
-    if (!session) return;
     if (method === 'notifications/initialized' && id === undefined) {
       session.initialized = true;
       res.status(202).end();
@@ -361,5 +378,7 @@ export function startServer(): void {
     console.log(`Kommo MCP Server listening on http://${host}:${port}`),
   );
 }
+
+export const MCP_PROTOCOL_VERSION = DEFAULT_MCP_PROTOCOL_VERSION;
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) startServer();

--- a/test/official-client.test.mjs
+++ b/test/official-client.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { createApp } from '../dist/http-streamable.js';
+
+test('official MCP client completes lifecycle and discovers capabilities', async (context) => {
+  const server = createApp({ logLevel: 'silent' }).listen(0, '127.0.0.1');
+  await new Promise((resolve) => server.once('listening', resolve));
+  context.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+
+  const client = new Client({ name: 'kommo-mcp-conformance-test', version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${address.port}/mcp`),
+  );
+  context.after(async () => client.close());
+
+  await client.connect(transport);
+
+  assert.equal(client.getProtocolEra(), 'legacy');
+  assert.equal(client.getServerVersion()?.name, 'kommo-mcp-server');
+
+  const [{ tools }, { resources }, { prompts }] = await Promise.all([
+    client.listTools(),
+    client.listResources(),
+    client.listPrompts(),
+  ]);
+
+  assert.equal(tools.length, 23);
+  assert.equal(resources.length, 5);
+  assert.equal(prompts.length, 4);
+
+  await transport.terminateSession();
+});


### PR DESCRIPTION
## Diagnóstico

O teste com `@modelcontextprotocol/client` 2.0.0 revelou que o servidor recusava a revisão `2025-11-25` negociada pelo cliente oficial, pois aceitava somente `2025-06-18`. A documentação do Claude Desktop também orientava incorretamente configurar um servidor HTTP remoto no `claude_desktop_config.json`.

Relaciona-se a #4.

## O que muda

- aceita e negocia revisões MCP legadas de `2024-11-05` a `2025-11-25`
- vincula cada sessão à revisão negociada e valida o header nas chamadas seguintes
- mantém retorno 404 para sessões encerradas ou desconhecidas
- adiciona `@modelcontextprotocol/client` como dependência de desenvolvimento
- adiciona teste ponta a ponta com o cliente oficial
- valida handshake, lifecycle, 23 tools, 5 resources, 4 prompts e encerramento de sessão
- corrige instruções do Claude Desktop para Settings → Connectors em implantações HTTPS

## Validação

- cliente MCP oficial conecta e identifica a era `legacy`
- `npm run typecheck`
- `npm run lint`
- `npm test` — 13/13
- `npm run format:check`
- `npm run audit:prod` — 0 vulnerabilidades
- `git diff --check`

## Compatibilidade

A revisão moderna `2026-07-28` ainda não é anunciada; o cliente oficial faz fallback automático para a era legada compatível.