### PR TITLE
fix: endurece integração Kommo e prepara v3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release artifacts
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install and validate
+        run: npm ci && npm test && npm run audit:prod && npm pack --dry-run
+
+      - name: Verify tag matches package version
+        run: test "v$(node -p "require('./package.json').version")" = "$GITHUB_REF_NAME"
+
+      - name: Publish npm with provenance
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        run: npm publish --provenance --access public
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and publish Docker image with SBOM and provenance
+        run: |
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          version="${GITHUB_REF_NAME#v}"
+          docker buildx create --use
+          docker buildx build \
+            --push \
+            --provenance=true \
+            --sbom=true \
+            --tag "$image:$version" \
+            --tag "$image:latest" \
+            .
+
+      - name: Create GitHub release notes
+        run: gh release view "$GITHUB_REF_NAME" || gh release create "$GITHUB_REF_NAME" --generate-notes --title "Kommo MCP Server $GITHUB_REF_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - Teste de conformidade ponta a ponta com o cliente MCP TypeScript oficial.
 - Validação JSON Schema dos argumentos de todas as tools pelo SDK oficial.
 - `ROADMAP.md` e `MAINTAINERS.md`.
+- Endpoint `/ready`, timeout configurável e retry seguro para leituras.
+- Anotações MCP de risco e confirmação opcional para operações de escrita.
+- Testes de contrato HTTP da API Kommo e cobertura de todas as tools anunciadas.
+- Workflow de release para imagem GHCR com SBOM/provenance e publicação npm opcional.
 
 ### Modificado
 
@@ -37,12 +41,18 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - Instruções atuais para conectores remotos do Claude Desktop.
 - Servidor migrado integralmente para o SDK MCP oficial v2 e para a revisão
   `2026-07-28`; clientes legados agora são rejeitados explicitamente.
+- Versão preparada para `3.0.0` devido à quebra de compatibilidade do protocolo.
+- Relatórios e dashboard passaram a ser calculados com endpoints públicos
+  documentados de leads, pipelines, usuários e tarefas.
+- Payloads de iniciar e parar Salesbot corrigidos conforme a API v4 oficial.
+- Falhas de paginação agora interrompem a operação em vez de retornar totais parciais.
 
 ### Removido
 
 - `GITHUB_UPDATE_INSTRUCTIONS.md` (documento interno que não deveria estar no repositório público).
 - Entrada `.dockerignore` do `.gitignore` (o `.dockerignore` agora é versionado).
 - Implementação MCP HTTP artesanal e sua validação AJV duplicada.
+- Chamadas analíticas para endpoints Kommo sem documentação pública.
 
 ## [2.0.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ src/
 ├── ask-kommo.ts          # Lógica conversacional do tool ask_kommo
 ├── http-streamable.ts    # Servidor MCP HTTP (Streamable HTTP)
 └── mcp/
+    ├── server.ts             # Registro oficial de tools/resources/prompts
     ├── types.ts             # Tipos internos do MCP
     ├── tool-definitions.ts  # Schemas (inputSchema) das tools
     ├── tool-handlers.ts     # Handlers de execução das tools
@@ -115,6 +116,8 @@ Ao adicionar uma nova tool:
 2. Implemente o handler em `src/mcp/tool-handlers.ts`.
 3. Se necessário, adicione o método na classe de `src/kommo-api.ts`.
 4. Documente a tool na tabela do `README.md`.
+5. Adicione um teste de handler e, se houver chamada HTTP nova, um teste de
+   contrato em `test/kommo-api.test.mjs`.
 
 ### Formatação e lint
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,13 @@ O servidor sobe em `http://127.0.0.1:3001/mcp`.
 | --------------------- | ------------------------------------------------------------ | ----------- |
 | `KOMMO_BASE_URL`      | URL da conta Kommo (`https://<subdominio>.kommo.com`)        | —           |
 | `KOMMO_ACCESS_TOKEN`  | Token de acesso (integração privada ou OAuth2)               | —           |
+| `KOMMO_TIMEOUT_MS`    | Timeout de cada requisição ao Kommo                          | `15000`     |
+| `KOMMO_MAX_RETRIES`   | Retentativas de leituras em `429`/`5xx`                      | `3`         |
 | `PORT`                | Porta HTTP do servidor MCP                                   | `3001`      |
 | `MCP_HOST`            | Host de binding                                              | `127.0.0.1` |
 | `MCP_ALLOWED_ORIGINS` | Origens permitidas (separadas por vírgula)                   | —           |
 | `MCP_AUTH_TOKEN`      | Protege `/mcp`; obrigatório quando `MCP_HOST` não é loopback | —           |
+| `MCP_CONFIRM_WRITES`  | Exige `confirm=true` nas tools que alteram dados             | `false`     |
 | `LOG_LEVEL`           | Nível de log                                                 | `info`      |
 
 ## Execução
@@ -123,6 +126,10 @@ docker run -d -p 3001:3001 \
 > Em produção, coloque o servidor atrás de um reverse proxy com TLS e defina
 > `MCP_AUTH_TOKEN` + `MCP_ALLOWED_ORIGINS`. O servidor se recusa a iniciar em
 > um endereço não local sem `MCP_AUTH_TOKEN`.
+
+> Ative `MCP_CONFIRM_WRITES=true` quando o cliente permitir confirmação
+> explícita. As tools de escrita anunciam `destructiveHint`; as consultas
+> anunciam `readOnlyHint` pelo protocolo MCP.
 
 ## Integração com clientes MCP
 
@@ -156,15 +163,17 @@ executados como processos; o Kommo MCP oferece atualmente transporte HTTP.
 - **MCP**: `POST http://localhost:3001/mcp` — negociação moderna via
   `server/discover`
 - **Health**: `GET http://localhost:3001/health`
+- **Readiness**: `GET http://localhost:3001/ready` — verifica se URL e token
+  obrigatórios foram configurados
 
 ## Ferramentas MCP
 
 ### Conta e dashboard
 
-| Tool            | Descrição                  |
-| --------------- | -------------------------- |
-| `get_account`   | Informações da conta Kommo |
-| `get_dashboard` | Dados do dashboard         |
+| Tool            | Descrição                                           |
+| --------------- | --------------------------------------------------- |
+| `get_account`   | Informações da conta Kommo                          |
+| `get_dashboard` | Dashboard calculado com endpoints públicos do Kommo |
 
 ### Leads
 
@@ -204,12 +213,12 @@ executados como processos; o Kommo MCP oferece atualmente transporte HTTP.
 
 ### Motivos de perda e Salesbot
 
-| Tool               | Descrição                        |
-| ------------------ | -------------------------------- |
-| `get_loss_reasons` | Listar motivos da perda de leads |
-| `get_loss_reason`  | Obter motivo de perda por ID     |
-| `run_salesbot`     | Iniciar Salesbot                 |
-| `stop_salesbot`    | Parar Salesbot                   |
+| Tool               | Descrição                                                     |
+| ------------------ | ------------------------------------------------------------- |
+| `get_loss_reasons` | Listar motivos da perda de leads                              |
+| `get_loss_reason`  | Obter motivo de perda por ID                                  |
+| `run_salesbot`     | Iniciar Salesbot (`bot_id`, `entity_id`, `entity_type=leads`) |
+| `stop_salesbot`    | Parar Salesbot (`bot_id`, `entity_id`, `entity_type=leads`)   |
 
 ### IA conversacional
 
@@ -285,6 +294,10 @@ Clientes limitados ao lifecycle MCP de 2024/2025 recebem o erro
   origem do cliente, quando definido.
 - **`403` no `/mcp`** — se `MCP_AUTH_TOKEN` estiver definido, é preciso
   enviar `Authorization: Bearer <token>` ou `X-API-Key: <token>`.
+- **`503` no `/ready`** — configure `KOMMO_BASE_URL` com HTTPS e defina
+  `KOMMO_ACCESS_TOKEN` antes de iniciar o serviço real.
+- **`429` do Kommo** — leituras são repetidas com backoff e `Retry-After`;
+  escritas não são repetidas automaticamente para evitar duplicidade.
 - **Docker `HEALTHCHECK` falha** — a imagem usa `node --eval` para o
   healthcheck, verifique se a porta interna corresponde a `PORT`.
 - **Erros de build TypeScript** — rode `npm run typecheck` para ver mensagens

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ O servidor sobe em `http://127.0.0.1:3001/mcp`.
 | `KOMMO_ACCESS_TOKEN`  | Token de acesso (integração privada ou OAuth2)               | —           |
 | `KOMMO_TIMEOUT_MS`    | Timeout de cada requisição ao Kommo                          | `15000`     |
 | `KOMMO_MAX_RETRIES`   | Retentativas de leituras em `429`/`5xx`                      | `3`         |
+| `KOMMO_TIMEZONE`      | Fuso IANA dos relatórios; por padrão usa o fuso da conta     | conta Kommo |
 | `PORT`                | Porta HTTP do servidor MCP                                   | `3001`      |
 | `MCP_HOST`            | Host de binding                                              | `127.0.0.1` |
 | `MCP_ALLOWED_ORIGINS` | Origens permitidas (separadas por vírgula)                   | —           |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,19 +2,15 @@
 
 Este roadmap orienta contribuições; não representa compromisso de prazo.
 
-## Agora — estabilização da versão 2
+## Agora — validação da versão 3
 
-- Ampliar testes dos handlers com respostas simuladas da API Kommo.
 - Validar Cursor e Claude Desktop de ponta a ponta e registrar versões testadas.
 - Validar a revisão MCP `2026-07-28` com mais clientes da comunidade.
-- Publicar imagens Docker reproduzíveis para releases versionadas.
+- Publicar a release `v3.0.0` após validação em uma conta Kommo de teste.
 
 ## Próximo
 
 - Adicionar transporte `stdio` para clientes locais.
-- Implementar retries com backoff e tratamento consistente de `429`.
-- Separar tools somente leitura das que alteram dados.
-- Adicionar modo de confirmação para operações destrutivas.
 - Publicar o pacote no npm após validar nome, conteúdo e provenance.
 
 ## Futuro

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Somente a versão mais recente do `main` recebe correções de segurança.
 
 | Versão | Suporte            |
 | ------ | ------------------ |
-| 2.x    | :white_check_mark: |
-| < 2.0  | :x:                |
+| 3.x    | :white_check_mark: |
+| < 3.0  | :x:                |
 
 ## Reportando uma vulnerabilidade
 

--- a/env.example
+++ b/env.example
@@ -3,6 +3,8 @@ KOMMO_BASE_URL=https://seu-dominio.kommo.com
 KOMMO_ACCESS_TOKEN=seu-token-aqui
 KOMMO_TIMEOUT_MS=15000
 KOMMO_MAX_RETRIES=3
+# Opcional: sobrescreve o fuso informado pela conta Kommo (formato IANA)
+# KOMMO_TIMEZONE=America/Sao_Paulo
 
 # Server Configuration
 PORT=3001

--- a/env.example
+++ b/env.example
@@ -1,6 +1,8 @@
 # Kommo CRM Configuration
 KOMMO_BASE_URL=https://seu-dominio.kommo.com
 KOMMO_ACCESS_TOKEN=seu-token-aqui
+KOMMO_TIMEOUT_MS=15000
+KOMMO_MAX_RETRIES=3
 
 # Server Configuration
 PORT=3001
@@ -10,6 +12,7 @@ MCP_HOST=127.0.0.1
 # Optional: Security
 # MCP_ALLOWED_ORIGINS=http://localhost:3000,https://cursor.com
 # MCP_AUTH_TOKEN=seu-token-mcp-aqui
+# MCP_CONFIRM_WRITES=true
 
 # Optional: Logging
 LOG_LEVEL=info

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kommo-mcp-server",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kommo-mcp-server",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",
@@ -446,15 +446,15 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "*"
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
@@ -485,10 +485,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
-      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3132,14 +3133,15 @@
       }
     },
     "node_modules/supertest": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
-      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
-        "superagent": "^10.2.3"
+        "superagent": "^10.3.0"
       },
       "engines": {
         "node": ">=14.18.0"
@@ -3325,10 +3327,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3430,9 +3433,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.0.tgz",
-      "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kommo-mcp-server",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "MCP (Model Context Protocol) Server for Kommo CRM integration — expõe tools, resources e prompts para clientes MCP como Cursor e Claude.",
   "main": "dist/http-streamable.js",
   "type": "module",
@@ -10,6 +10,7 @@
     "start": "node dist/http-streamable.js",
     "dev": "ts-node --esm src/http-streamable.ts",
     "test": "npm run build && node --test test/*.test.mjs",
+    "prepublishOnly": "npm run typecheck && npm run lint && npm test && npm run audit:prod",
     "audit:prod": "npm audit --omit=dev --audit-level=high",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.ts\" --max-warnings=0",

--- a/src/ask-kommo.ts
+++ b/src/ask-kommo.ts
@@ -310,17 +310,14 @@ export async function handleAskKommo(kommoAPI: KommoAPI, question: string): Prom
     questionLower.includes('ganho')
   ) {
     let salesLeads = leadsArray.filter((lead) => {
-      const status = lead.status?.toString().toLowerCase() || '';
-      const isClosedStatus =
-        status.includes('fechado') || status.includes('ganho') || status.includes('concluído');
-      return isClosedStatus || (lead.price || 0) > 0;
+      return lead.status_id === 142;
     });
 
     if (temporalFilter) {
       const { start, end } = getDateRange(temporalFilter);
       salesLeads = salesLeads.filter((lead) => {
-        const updatedAt = new Date(lead.updated_at * 1000);
-        return updatedAt >= start && updatedAt <= end;
+        const closedAt = new Date((lead.closed_at ?? 0) * 1000);
+        return closedAt >= start && closedAt <= end;
       });
     }
 

--- a/src/http-streamable.ts
+++ b/src/http-streamable.ts
@@ -35,6 +35,13 @@ export function validateRuntimeConfig(env: NodeJS.ProcessEnv = process.env): str
     }
   }
   if (!env.KOMMO_ACCESS_TOKEN) issues.push('KOMMO_ACCESS_TOKEN is required');
+  if (env.KOMMO_TIMEZONE) {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: env.KOMMO_TIMEZONE }).format();
+    } catch {
+      issues.push('KOMMO_TIMEZONE must be a valid IANA timezone');
+    }
+  }
   return issues;
 }
 
@@ -79,6 +86,7 @@ export function createApp(options: AppOptions = {}) {
       accessToken: process.env.KOMMO_ACCESS_TOKEN || '',
       timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS) || 15_000,
       maxRetries: Number(process.env.KOMMO_MAX_RETRIES) || 3,
+      timezone: process.env.KOMMO_TIMEZONE,
     });
   const logger = {
     error: (message: string, error?: unknown) => {

--- a/src/http-streamable.ts
+++ b/src/http-streamable.ts
@@ -14,12 +14,28 @@ import { createKommoMcpServer } from './mcp/server.js';
 dotenv.config();
 
 const MODERN_MCP_PROTOCOL_VERSION = '2026-07-28';
+const SERVER_VERSION = '3.0.0';
 
 interface AppOptions {
   kommoAPI?: KommoAPI;
   authToken?: string;
   allowedOrigins?: string[];
   logLevel?: string;
+}
+
+export function validateRuntimeConfig(env: NodeJS.ProcessEnv = process.env): string[] {
+  const issues: string[] = [];
+  if (!env.KOMMO_BASE_URL) issues.push('KOMMO_BASE_URL is required');
+  else {
+    try {
+      const url = new URL(env.KOMMO_BASE_URL);
+      if (url.protocol !== 'https:') issues.push('KOMMO_BASE_URL must use HTTPS');
+    } catch {
+      issues.push('KOMMO_BASE_URL must be a valid URL');
+    }
+  }
+  if (!env.KOMMO_ACCESS_TOKEN) issues.push('KOMMO_ACCESS_TOKEN is required');
+  return issues;
 }
 
 function isLoopbackOrigin(origin: string): boolean {
@@ -55,11 +71,14 @@ export function createApp(options: AppOptions = {}) {
       .filter(Boolean) ??
     [];
   const authToken = options.authToken ?? process.env.MCP_AUTH_TOKEN;
+  const configIssues = options.kommoAPI ? [] : validateRuntimeConfig();
   const kommoAPI =
     options.kommoAPI ??
     new KommoAPI({
       baseUrl: process.env.KOMMO_BASE_URL || 'https://api-g.kommo.com',
       accessToken: process.env.KOMMO_ACCESS_TOKEN || '',
+      timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS) || 15_000,
+      maxRetries: Number(process.env.KOMMO_MAX_RETRIES) || 3,
     });
   const logger = {
     error: (message: string, error?: unknown) => {
@@ -105,13 +124,21 @@ export function createApp(options: AppOptions = {}) {
     res.json({
       status: 'healthy',
       timestamp: new Date().toISOString(),
-      version: '2.0.0',
+      version: SERVER_VERSION,
       protocol_version: MODERN_MCP_PROTOCOL_VERSION,
       tools_count: MCP_TOOLS.length,
       resources_count: MCP_RESOURCES.length,
       prompts_count: MCP_PROMPTS.length,
       environment: process.env.NODE_ENV || 'development',
     });
+  });
+
+  app.get('/ready', (_req, res) => {
+    if (configIssues.length > 0) {
+      res.status(503).json({ status: 'not_ready', issues: configIssues });
+      return;
+    }
+    res.json({ status: 'ready', timestamp: new Date().toISOString() });
   });
 
   app.use('/mcp', (req, res, next) => {
@@ -141,6 +168,8 @@ export function startServer(): void {
   if (!['127.0.0.1', 'localhost', '::1'].includes(host) && !process.env.MCP_AUTH_TOKEN) {
     throw new Error('MCP_AUTH_TOKEN is required when MCP_HOST is not a loopback address');
   }
+  const configIssues = validateRuntimeConfig();
+  if (configIssues.length > 0) throw new Error(configIssues.join('; '));
   createApp().listen(port, host, () =>
     console.log(`Kommo MCP Server listening on http://${host}:${port}`),
   );

--- a/src/kommo-api.ts
+++ b/src/kommo-api.ts
@@ -1,8 +1,22 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
 
 export interface KommoConfig {
   baseUrl: string;
   accessToken: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+}
+
+interface RetryableRequestConfig extends InternalAxiosRequestConfig {
+  retryCount?: number;
+}
+
+export function parseRetryAfter(value: unknown, now = Date.now()): number | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const timestamp = Date.parse(String(value));
+  return Number.isNaN(timestamp) ? undefined : Math.max(0, timestamp - now);
 }
 
 export type KommoQueryParams = Record<string, string | number | boolean | undefined>;
@@ -105,36 +119,10 @@ export interface KommoTask {
   created_at: number;
   updated_at: number;
   complete_till: number;
+  is_completed?: boolean;
   result?: {
     text: string;
   };
-}
-
-// Novas interfaces para Eventos e Atividades
-export interface KommoEvent {
-  id: number;
-  entity_id: number;
-  entity_type: string;
-  type: string;
-  created_at: number;
-  updated_at: number;
-  created_by: number;
-  responsible_user_id: number;
-  text?: string;
-  data?: unknown;
-}
-
-export interface KommoActivity {
-  id: number;
-  entity_id: number;
-  entity_type: string;
-  type: string;
-  created_at: number;
-  updated_at: number;
-  created_by: number;
-  responsible_user_id: number;
-  text?: string;
-  data?: unknown;
 }
 
 // Novas interfaces para Status
@@ -233,12 +221,33 @@ export class KommoAPI {
   private client: AxiosInstance;
 
   constructor(config: KommoConfig) {
+    const maxRetries = config.maxRetries ?? 3;
     this.client = axios.create({
       baseURL: config.baseUrl,
+      timeout: config.timeoutMs ?? 15_000,
       headers: {
         Authorization: `Bearer ${config.accessToken}`,
         'Content-Type': 'application/json',
       },
+    });
+    this.client.interceptors.response.use(undefined, async (error: unknown) => {
+      if (!axios.isAxiosError(error) || !error.config) throw error;
+      const request = error.config as RetryableRequestConfig;
+      const method = request.method?.toUpperCase() ?? 'GET';
+      const status = error.response?.status;
+      const retryableMethod = ['GET', 'HEAD', 'OPTIONS'].includes(method);
+      const retryableFailure =
+        status === 429 || status === 502 || status === 503 || status === 504 || !error.response;
+      request.retryCount = request.retryCount ?? 0;
+      if (!retryableMethod || !retryableFailure || request.retryCount >= maxRetries) throw error;
+
+      request.retryCount += 1;
+      const retryAfter = error.response?.headers['retry-after'];
+      const retryAfterMs = parseRetryAfter(retryAfter);
+      const backoffMs = Math.min(250 * 2 ** (request.retryCount - 1), 4_000);
+      const jitterMs = Math.floor(Math.random() * 100);
+      await new Promise((resolve) => setTimeout(resolve, retryAfterMs ?? backoffMs + jitterMs));
+      return this.client.request(request);
     });
   }
 
@@ -259,45 +268,34 @@ export class KommoAPI {
     let page = 1;
     let hasMore = true;
     const limit = 250; // API limit per page
-    let consecutiveEmptyPages = 0;
-    const maxEmptyPages = 2; // Stop after 2 consecutive empty pages
 
-    while (hasMore && consecutiveEmptyPages < maxEmptyPages) {
-      try {
-        const response = await this.client.get('/api/v4/leads', {
-          params: {
-            ...params,
-            limit,
-            page,
-          },
-        });
-
-        const data = response.data;
-        const leads = data._embedded?.leads || [];
-
-        if (leads.length === 0) {
-          consecutiveEmptyPages++;
-        } else {
-          consecutiveEmptyPages = 0;
-          allLeads.push(...leads);
-        }
-
-        page++;
-
-        // Check if there's a next page
-        hasMore = !!data._links?.next;
-
-        // Add small delay to avoid rate limiting
-        if (hasMore) {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
-      } catch (error) {
-        console.error(`Error fetching page ${page}:`, error);
-        break;
-      }
+    while (hasMore) {
+      const response = await this.client.get('/api/v4/leads', {
+        params: { ...params, limit, page },
+      });
+      const data = response.data;
+      allLeads.push(...(data._embedded?.leads ?? []));
+      hasMore = Boolean(data._links?.next);
+      page += 1;
     }
 
     return allLeads;
+  }
+
+  async getAllTasks(params?: KommoQueryParams): Promise<KommoTask[]> {
+    const allTasks: KommoTask[] = [];
+    let page = 1;
+    let hasMore = true;
+    while (hasMore) {
+      const response = await this.client.get('/api/v4/tasks', {
+        params: { ...params, limit: 250, page },
+      });
+      const data = response.data;
+      allTasks.push(...(data._embedded?.tasks ?? []));
+      hasMore = Boolean(data._links?.next);
+      page += 1;
+    }
+    return allTasks;
   }
 
   async getLead(id: number): Promise<KommoLead> {
@@ -415,65 +413,6 @@ export class KommoAPI {
     return response.data;
   }
 
-  // ===== NOVOS MÉTODOS: GESTÃO DE EVENTOS E ATIVIDADES =====
-
-  // Eventos de leads
-  async getLeadEvents(
-    leadId: number,
-    params?: KommoQueryParams,
-  ): Promise<{ _embedded: { events: KommoEvent[] } }> {
-    const response = await this.client.get(`/api/v4/leads/${leadId}/events`, { params });
-    return response.data;
-  }
-
-  async createLeadEvent(leadId: number, eventData: Partial<KommoEvent>): Promise<KommoEvent> {
-    const response = await this.client.post(`/api/v4/leads/${leadId}/events`, [eventData]);
-    return response.data._embedded.events[0];
-  }
-
-  async updateLeadEvent(
-    leadId: number,
-    eventId: number,
-    eventData: Partial<KommoEvent>,
-  ): Promise<KommoEvent> {
-    const response = await this.client.patch(
-      `/api/v4/leads/${leadId}/events/${eventId}`,
-      eventData,
-    );
-    return response.data;
-  }
-
-  // Atividades de contatos
-  async getContactActivities(
-    contactId: number,
-    params?: KommoQueryParams,
-  ): Promise<{ _embedded: { activities: KommoActivity[] } }> {
-    const response = await this.client.get(`/api/v4/contacts/${contactId}/activities`, { params });
-    return response.data;
-  }
-
-  async createContactActivity(
-    contactId: number,
-    activityData: Partial<KommoActivity>,
-  ): Promise<KommoActivity> {
-    const response = await this.client.post(`/api/v4/contacts/${contactId}/activities`, [
-      activityData,
-    ]);
-    return response.data._embedded.activities[0];
-  }
-
-  async updateContactActivity(
-    contactId: number,
-    activityId: number,
-    activityData: Partial<KommoActivity>,
-  ): Promise<KommoActivity> {
-    const response = await this.client.patch(
-      `/api/v4/contacts/${contactId}/activities/${activityId}`,
-      activityData,
-    );
-    return response.data;
-  }
-
   // ===== NOVOS MÉTODOS: GESTÃO DE STATUS E PIPELINES =====
 
   // Status de leads
@@ -521,85 +460,153 @@ export class KommoAPI {
     return response.data;
   }
 
-  // ===== NOVOS MÉTODOS: RELATÓRIOS E ANALYTICS =====
+  // ===== RELATÓRIOS CALCULADOS COM ENDPOINTS PÚBLICOS =====
 
-  // Relatórios de vendas
   async getSalesReport(dateFrom: string, dateTo: string): Promise<KommoSalesReport> {
-    const response = await this.client.get('/api/v4/leads/reports', {
-      params: {
-        date_from: dateFrom,
-        date_to: dateTo,
-        report_type: 'sales',
+    const from = Math.floor(new Date(`${dateFrom}T00:00:00.000Z`).getTime() / 1000);
+    const to = Math.floor(new Date(`${dateTo}T23:59:59.999Z`).getTime() / 1000);
+    if (!Number.isFinite(from) || !Number.isFinite(to) || from > to) {
+      throw new Error('Período inválido. Use datas no formato YYYY-MM-DD.');
+    }
+    const [leads, pipelinesResponse, usersResponse] = await Promise.all([
+      this.getAllLeads(),
+      this.getPipelines(),
+      this.getUsers(),
+    ]);
+    const created = leads.filter((lead) => lead.created_at >= from && lead.created_at <= to);
+    const closed = leads.filter(
+      (lead) => lead.closed_at !== undefined && lead.closed_at >= from && lead.closed_at <= to,
+    );
+    const won = closed.filter((lead) => lead.status_id === 142);
+    const lost = closed.filter((lead) => lead.status_id === 143);
+    const revenue = won.reduce((sum, lead) => sum + (lead.price || 0), 0);
+    const pipelineNames = new Map(
+      (pipelinesResponse._embedded?.pipelines ?? []).map((pipeline) => [
+        pipeline.id,
+        pipeline.name,
+      ]),
+    );
+    const userNames = new Map(
+      (usersResponse._embedded?.users ?? []).map((user) => [user.id, user.name]),
+    );
+    const aggregate = <T extends number>(
+      items: KommoLead[],
+      key: (lead: KommoLead) => T,
+      name: (id: T) => string,
+    ) =>
+      Array.from(
+        items.reduce((groups, lead) => {
+          const id = key(lead);
+          const current = groups.get(id) ?? { count: 0, revenue: 0 };
+          current.count += 1;
+          current.revenue += lead.price || 0;
+          groups.set(id, current);
+          return groups;
+        }, new Map<T, { count: number; revenue: number }>()),
+      ).map(([id, values]) => ({ id, name: name(id), ...values }));
+    const byUser = aggregate(
+      won,
+      (lead) => lead.responsible_user_id,
+      (id) => userNames.get(id) ?? String(id),
+    );
+    const byPipeline = aggregate(
+      won,
+      (lead) => lead.pipeline_id,
+      (id) => pipelineNames.get(id) ?? String(id),
+    );
+
+    return {
+      period: { from: dateFrom, to: dateTo },
+      leads: { total: created.length, new: created.length, won: won.length, lost: lost.length },
+      revenue: {
+        total: revenue,
+        average: won.length > 0 ? revenue / won.length : 0,
+        conversion_rate:
+          won.length + lost.length > 0 ? (won.length / (won.length + lost.length)) * 100 : 0,
       },
-    });
-    return response.data;
+      performance: {
+        by_user: byUser.map(({ id, name, count, revenue: value }) => ({
+          user_id: id,
+          user_name: name,
+          leads_count: count,
+          revenue: value,
+        })),
+        by_pipeline: byPipeline.map(({ id, name, count, revenue: value }) => ({
+          pipeline_id: id,
+          pipeline_name: name,
+          leads_count: count,
+          revenue: value,
+        })),
+      },
+    };
   }
 
-  async getLeadConversionReport(
-    dateFrom: string,
-    dateTo: string,
-  ): Promise<Record<string, unknown>> {
-    const response = await this.client.get('/api/v4/leads/reports', {
-      params: {
-        date_from: dateFrom,
-        date_to: dateTo,
-        report_type: 'conversion',
-      },
-    });
-    return response.data;
-  }
-
-  async getPipelinePerformanceReport(
-    dateFrom: string,
-    dateTo: string,
-  ): Promise<Record<string, unknown>> {
-    const response = await this.client.get('/api/v4/leads/pipelines/reports', {
-      params: {
-        date_from: dateFrom,
-        date_to: dateTo,
-      },
-    });
-    return response.data;
-  }
-
-  // Dashboard data
   async getDashboardData(): Promise<KommoDashboardData> {
-    const response = await this.client.get('/api/v4/dashboard');
-    return response.data;
-  }
-
-  async getUserPerformanceStats(
-    userId: number,
-    dateFrom?: string,
-    dateTo?: string,
-  ): Promise<Record<string, unknown>> {
-    const params: KommoQueryParams = {};
-    if (dateFrom) params.date_from = dateFrom;
-    if (dateTo) params.date_to = dateTo;
-
-    const response = await this.client.get(`/api/v4/users/${userId}/performance`, { params });
-    return response.data;
-  }
-
-  // Analytics avançados
-  async getLeadAnalytics(leadId: number): Promise<Record<string, unknown>> {
-    const response = await this.client.get(`/api/v4/leads/${leadId}/analytics`);
-    return response.data;
-  }
-
-  async getPipelineAnalytics(
-    pipelineId: number,
-    dateFrom?: string,
-    dateTo?: string,
-  ): Promise<Record<string, unknown>> {
-    const params: KommoQueryParams = {};
-    if (dateFrom) params.date_from = dateFrom;
-    if (dateTo) params.date_to = dateTo;
-
-    const response = await this.client.get(`/api/v4/leads/pipelines/${pipelineId}/analytics`, {
-      params,
-    });
-    return response.data;
+    const [leads, tasks, pipelinesResponse] = await Promise.all([
+      this.getAllLeads(),
+      this.getAllTasks(),
+      this.getPipelines(),
+    ]);
+    const now = new Date();
+    const todayStart = Math.floor(
+      new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime() / 1000,
+    );
+    const monthStart = Math.floor(new Date(now.getFullYear(), now.getMonth(), 1).getTime() / 1000);
+    const lastMonthStart = Math.floor(
+      new Date(now.getFullYear(), now.getMonth() - 1, 1).getTime() / 1000,
+    );
+    const won = leads.filter((lead) => lead.status_id === 142);
+    const revenueForPeriod = (from: number, to: number) =>
+      won
+        .filter(
+          (lead) => lead.closed_at !== undefined && lead.closed_at >= from && lead.closed_at < to,
+        )
+        .reduce((sum, lead) => sum + (lead.price || 0), 0);
+    const thisMonth = revenueForPeriod(monthStart, Math.floor(now.getTime() / 1000) + 1);
+    const lastMonth = revenueForPeriod(lastMonthStart, monthStart);
+    const pipelineNames = new Map(
+      (pipelinesResponse._embedded?.pipelines ?? []).map((pipeline) => [
+        pipeline.id,
+        pipeline.name,
+      ]),
+    );
+    const pipelineTotals = new Map<number, { leads_count: number; revenue: number }>();
+    for (const lead of leads) {
+      const current = pipelineTotals.get(lead.pipeline_id) ?? { leads_count: 0, revenue: 0 };
+      current.leads_count += 1;
+      if (lead.status_id === 142) current.revenue += lead.price || 0;
+      pipelineTotals.set(lead.pipeline_id, current);
+    }
+    return {
+      leads: {
+        total: leads.length,
+        new_today: leads.filter((lead) => lead.created_at >= todayStart).length,
+        won_today: won.filter((lead) => (lead.closed_at ?? 0) >= todayStart).length,
+        lost_today: leads.filter(
+          (lead) => lead.status_id === 143 && (lead.closed_at ?? 0) >= todayStart,
+        ).length,
+      },
+      tasks: {
+        total: tasks.length,
+        completed_today: tasks.filter((task) => task.is_completed && task.updated_at >= todayStart)
+          .length,
+        overdue: tasks.filter(
+          (task) => !task.is_completed && task.complete_till < Math.floor(now.getTime() / 1000),
+        ).length,
+      },
+      revenue: {
+        this_month: thisMonth,
+        last_month: lastMonth,
+        growth_percentage: lastMonth > 0 ? ((thisMonth - lastMonth) / lastMonth) * 100 : 0,
+      },
+      top_pipelines: Array.from(pipelineTotals, ([id, values]) => ({
+        id,
+        name: pipelineNames.get(id) ?? String(id),
+        ...values,
+      }))
+        .sort((a, b) => b.revenue - a.revenue)
+        .slice(0, 5),
+    };
   }
 
   // ===== NOTAS =====
@@ -632,17 +639,18 @@ export class KommoAPI {
   }
 
   // ===== SALESBOT (API v4 2026) =====
-  async runSalesbot(params: {
-    entity_id: number;
-    entity_type: string;
-    [key: string]: unknown;
-  }): Promise<unknown> {
-    const response = await this.client.post('/api/v4/bots/run', params);
-    return response.data;
+  async runSalesbot(botId: number, entityId: number, entityType: 'leads'): Promise<unknown> {
+    const response = await this.client.post('/api/v4/bots/run', [
+      { bot_id: botId, entity_id: entityId, entity_type: entityType },
+    ]);
+    return { accepted: response.status === 202 };
   }
 
-  async stopSalesbot(botId: number): Promise<unknown> {
-    const response = await this.client.post(`/api/v4/bots/${botId}/stop`);
-    return response.data;
+  async stopSalesbot(botId: number, entityId: number, entityType: 'leads'): Promise<unknown> {
+    const response = await this.client.post(`/api/v4/bots/${botId}/stop`, {
+      entity_id: entityId,
+      entity_type: entityType,
+    });
+    return { accepted: response.status === 202 };
   }
 }

--- a/src/kommo-api.ts
+++ b/src/kommo-api.ts
@@ -5,6 +5,98 @@ export interface KommoConfig {
   accessToken: string;
   timeoutMs?: number;
   maxRetries?: number;
+  timezone?: string;
+}
+
+interface CalendarDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+function assertTimezone(timezone: string): void {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format();
+  } catch {
+    throw new Error(`Fuso horário inválido: ${timezone}`);
+  }
+}
+
+function parseCalendarDate(value: string): CalendarDate {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) throw new Error('Período inválido. Use datas no formato YYYY-MM-DD.');
+  const [, yearText, monthText, dayText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const normalized = new Date(Date.UTC(year, month - 1, day));
+  if (
+    normalized.getUTCFullYear() !== year ||
+    normalized.getUTCMonth() !== month - 1 ||
+    normalized.getUTCDate() !== day
+  ) {
+    throw new Error('Período inválido. Use datas reais no formato YYYY-MM-DD.');
+  }
+  return { year, month, day };
+}
+
+function addCalendarDays(date: CalendarDate, days: number): CalendarDate {
+  const result = new Date(Date.UTC(date.year, date.month - 1, date.day + days));
+  return {
+    year: result.getUTCFullYear(),
+    month: result.getUTCMonth() + 1,
+    day: result.getUTCDate(),
+  };
+}
+
+function zonedStartOfDay(date: CalendarDate, timezone: string): number {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  });
+  const desired = Date.UTC(date.year, date.month - 1, date.day);
+  let instant = desired;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const parts = Object.fromEntries(
+      formatter
+        .formatToParts(instant)
+        .filter((part) => part.type !== 'literal')
+        .map((part) => [part.type, Number(part.value)]),
+    );
+    const represented = Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+    );
+    const adjustment = desired - represented;
+    instant += adjustment;
+    if (adjustment === 0) break;
+  }
+  return Math.floor(instant / 1000);
+}
+
+function zonedCalendarDate(instant: Date, timezone: string): CalendarDate {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+      .formatToParts(instant)
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, Number(part.value)]),
+  );
+  return { year: parts.year, month: parts.month, day: parts.day };
 }
 
 interface RetryableRequestConfig extends InternalAxiosRequestConfig {
@@ -219,8 +311,11 @@ export interface KommoDashboardData {
 
 export class KommoAPI {
   private client: AxiosInstance;
+  private configuredTimezone?: string;
 
   constructor(config: KommoConfig) {
+    if (config.timezone) assertTimezone(config.timezone);
+    this.configuredTimezone = config.timezone;
     const maxRetries = config.maxRetries ?? 3;
     this.client = axios.create({
       baseURL: config.baseUrl,
@@ -255,6 +350,12 @@ export class KommoAPI {
   async getAccount(): Promise<KommoAccount> {
     const response = await this.client.get('/api/v4/account');
     return response.data;
+  }
+
+  private getBusinessTimezone(account: KommoAccount): string {
+    const timezone = this.configuredTimezone ?? account.timezone ?? 'UTC';
+    assertTimezone(timezone);
+    return timezone;
   }
 
   // Leads methods
@@ -463,19 +564,26 @@ export class KommoAPI {
   // ===== RELATÓRIOS CALCULADOS COM ENDPOINTS PÚBLICOS =====
 
   async getSalesReport(dateFrom: string, dateTo: string): Promise<KommoSalesReport> {
-    const from = Math.floor(new Date(`${dateFrom}T00:00:00.000Z`).getTime() / 1000);
-    const to = Math.floor(new Date(`${dateTo}T23:59:59.999Z`).getTime() / 1000);
-    if (!Number.isFinite(from) || !Number.isFinite(to) || from > to) {
-      throw new Error('Período inválido. Use datas no formato YYYY-MM-DD.');
-    }
-    const [leads, pipelinesResponse, usersResponse] = await Promise.all([
+    const fromDate = parseCalendarDate(dateFrom);
+    const toDate = parseCalendarDate(dateTo);
+    const [account, leads, pipelinesResponse, usersResponse] = await Promise.all([
+      this.getAccount(),
       this.getAllLeads(),
       this.getPipelines(),
       this.getUsers(),
     ]);
-    const created = leads.filter((lead) => lead.created_at >= from && lead.created_at <= to);
+    const timezone = this.getBusinessTimezone(account);
+    const from = zonedStartOfDay(fromDate, timezone);
+    const toExclusive = zonedStartOfDay(addCalendarDays(toDate, 1), timezone);
+    if (from >= toExclusive) {
+      throw new Error('Período inválido. Use datas no formato YYYY-MM-DD.');
+    }
+    const created = leads.filter(
+      (lead) => lead.created_at >= from && lead.created_at < toExclusive,
+    );
     const closed = leads.filter(
-      (lead) => lead.closed_at !== undefined && lead.closed_at >= from && lead.closed_at <= to,
+      (lead) =>
+        lead.closed_at !== undefined && lead.closed_at >= from && lead.closed_at < toExclusive,
     );
     const won = closed.filter((lead) => lead.status_id === 142);
     const lost = closed.filter((lead) => lead.status_id === 143);
@@ -542,18 +650,25 @@ export class KommoAPI {
   }
 
   async getDashboardData(): Promise<KommoDashboardData> {
-    const [leads, tasks, pipelinesResponse] = await Promise.all([
+    const [account, leads, tasks, pipelinesResponse] = await Promise.all([
+      this.getAccount(),
       this.getAllLeads(),
       this.getAllTasks(),
       this.getPipelines(),
     ]);
     const now = new Date();
-    const todayStart = Math.floor(
-      new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime() / 1000,
-    );
-    const monthStart = Math.floor(new Date(now.getFullYear(), now.getMonth(), 1).getTime() / 1000);
-    const lastMonthStart = Math.floor(
-      new Date(now.getFullYear(), now.getMonth() - 1, 1).getTime() / 1000,
+    const timezone = this.getBusinessTimezone(account);
+    const today = zonedCalendarDate(now, timezone);
+    const todayStart = zonedStartOfDay(today, timezone);
+    const monthStart = zonedStartOfDay({ ...today, day: 1 }, timezone);
+    const previousMonthDate = new Date(Date.UTC(today.year, today.month - 2, 1));
+    const lastMonthStart = zonedStartOfDay(
+      {
+        year: previousMonthDate.getUTCFullYear(),
+        month: previousMonthDate.getUTCMonth() + 1,
+        day: 1,
+      },
+      timezone,
     );
     const won = leads.filter((lead) => lead.status_id === 142);
     const revenueForPeriod = (from: number, to: number) =>

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,5 @@
 import { McpServer, fromJsonSchema } from '@modelcontextprotocol/server';
+import axios from 'axios';
 import { z } from 'zod';
 import { KommoAPI } from '../kommo-api.js';
 import { MCP_TOOLS } from './tool-definitions.js';
@@ -6,22 +7,95 @@ import { executeTool } from './tool-handlers.js';
 import { MCP_RESOURCES, readResource } from './resources.js';
 import { MCP_PROMPTS, getPromptMessages } from './prompts.js';
 
+const WRITE_TOOLS = new Set([
+  'create_lead',
+  'update_lead',
+  'move_lead',
+  'create_task',
+  'add_note',
+  'pin_note',
+  'unpin_note',
+  'run_salesbot',
+  'stop_salesbot',
+]);
+
+function safeToolError(error: unknown) {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status;
+    const message =
+      status === 401
+        ? 'A autenticação com o Kommo falhou.'
+        : status === 403
+          ? 'A credencial não possui permissão para esta operação.'
+          : status === 404
+            ? 'O recurso solicitado não foi encontrado no Kommo.'
+            : status === 429
+              ? 'O limite de requisições do Kommo foi atingido. Tente novamente mais tarde.'
+              : error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT'
+                ? 'A requisição ao Kommo excedeu o tempo limite.'
+                : 'A API do Kommo não conseguiu concluir a operação.';
+    return { content: [{ type: 'text' as const, text: message }], isError: true };
+  }
+  return {
+    content: [{ type: 'text' as const, text: 'Erro interno ao executar a tool.' }],
+    isError: true,
+  };
+}
+
 export function createKommoMcpServer(kommoAPI: KommoAPI): McpServer {
   const server = new McpServer({
     name: 'kommo-mcp-server',
-    version: '2.0.0',
+    version: '3.0.0',
     description: 'MCP Server for Kommo CRM integration',
   });
 
   for (const tool of MCP_TOOLS) {
+    const isWrite = WRITE_TOOLS.has(tool.name);
+    const schema = isWrite
+      ? {
+          ...tool.inputSchema,
+          properties: {
+            ...((tool.inputSchema.properties as Record<string, unknown> | undefined) ?? {}),
+            confirm: {
+              type: 'boolean',
+              description: 'Confirma explicitamente a operação de escrita quando exigido.',
+            },
+          },
+        }
+      : tool.inputSchema;
     server.registerTool(
       tool.name,
       {
         title: tool.title,
         description: tool.description,
-        inputSchema: fromJsonSchema<Record<string, unknown>>(tool.inputSchema),
+        inputSchema: fromJsonSchema<Record<string, unknown>>(schema),
+        annotations: {
+          readOnlyHint: !isWrite,
+          destructiveHint: isWrite,
+          idempotentHint: !isWrite || tool.name === 'pin_note' || tool.name === 'unpin_note',
+          openWorldHint: true,
+        },
       },
-      async (args) => executeTool(kommoAPI, tool.name, args),
+      async (args) => {
+        if (isWrite && process.env.MCP_CONFIRM_WRITES === 'true' && args.confirm !== true) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Esta operação exige confirm=true porque MCP_CONFIRM_WRITES está ativo.',
+              },
+            ],
+            isError: true,
+          };
+        }
+        const toolArgs = { ...args };
+        delete toolArgs.confirm;
+        try {
+          return await executeTool(kommoAPI, tool.name, toolArgs);
+        } catch (error) {
+          return safeToolError(error);
+        }
+      },
     );
   }
 
@@ -35,13 +109,19 @@ export function createKommoMcpServer(kommoAPI: KommoAPI): McpServer {
         mimeType: resource.mimeType,
       },
       async (uri) => ({
-        contents: [
-          {
-            uri: uri.href,
-            mimeType: resource.mimeType,
-            text: await readResource(kommoAPI, uri.href),
-          },
-        ],
+        contents: await (async () => {
+          try {
+            return [
+              {
+                uri: uri.href,
+                mimeType: resource.mimeType,
+                text: await readResource(kommoAPI, uri.href),
+              },
+            ];
+          } catch {
+            throw new Error('Não foi possível carregar este resource do Kommo.');
+          }
+        })(),
       }),
     );
   }

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -264,11 +264,12 @@ export const MCP_TOOLS: McpToolDefinition[] = [
     inputSchema: {
       type: 'object',
       properties: {
+        bot_id: { type: 'number', description: 'ID do Salesbot' },
         entity_id: { type: 'number', description: 'ID da entidade (ex.: lead)' },
-        entity_type: { type: 'string', description: 'Tipo da entidade (ex.: leads)' },
+        entity_type: { type: 'string', enum: ['leads'], description: 'Tipo da entidade' },
       },
-      required: ['entity_id', 'entity_type'],
-      additionalProperties: true,
+      required: ['bot_id', 'entity_id', 'entity_type'],
+      additionalProperties: false,
     },
   },
   {
@@ -279,8 +280,10 @@ export const MCP_TOOLS: McpToolDefinition[] = [
       type: 'object',
       properties: {
         bot_id: { type: 'number', description: 'ID do bot Salesbot' },
+        entity_id: { type: 'number', description: 'ID do lead' },
+        entity_type: { type: 'string', enum: ['leads'], description: 'Tipo da entidade' },
       },
-      required: ['bot_id'],
+      required: ['bot_id', 'entity_id', 'entity_type'],
       additionalProperties: false,
     },
   },

--- a/src/mcp/tool-handlers.ts
+++ b/src/mcp/tool-handlers.ts
@@ -190,20 +190,23 @@ export async function executeTool(
     }
 
     case 'run_salesbot': {
+      const botId = args?.bot_id as number;
       const entityId = args?.entity_id as number;
-      const entityType = args?.entity_type as string;
-      if (typeof entityId !== 'number' || !entityType) {
-        return errorResult('Requer entity_id (número) e entity_type (ex.: leads).');
+      const entityType = args?.entity_type;
+      if (typeof botId !== 'number' || typeof entityId !== 'number' || entityType !== 'leads') {
+        return errorResult('Requer bot_id, entity_id (números) e entity_type="leads".');
       }
-      return textResult(
-        await kommoAPI.runSalesbot({ entity_id: entityId, entity_type: entityType, ...args }),
-      );
+      return textResult(await kommoAPI.runSalesbot(botId, entityId, entityType));
     }
 
     case 'stop_salesbot': {
       const botId = args?.bot_id as number;
-      if (typeof botId !== 'number') return errorResult('Requer bot_id (número).');
-      return textResult(await kommoAPI.stopSalesbot(botId));
+      const entityId = args?.entity_id as number;
+      const entityType = args?.entity_type;
+      if (typeof botId !== 'number' || typeof entityId !== 'number' || entityType !== 'leads') {
+        return errorResult('Requer bot_id, entity_id (números) e entity_type="leads".');
+      }
+      return textResult(await kommoAPI.stopSalesbot(botId, entityId, entityType));
     }
 
     case 'ask_kommo':

--- a/test/http-streamable.test.mjs
+++ b/test/http-streamable.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import request from 'supertest';
-import { createApp } from '../dist/http-streamable.js';
+import { createApp, validateRuntimeConfig } from '../dist/http-streamable.js';
 
 const accept = 'application/json, text/event-stream';
 
@@ -25,6 +25,24 @@ test('health reports the modern protocol without exposing the Kommo account URL'
   assert.equal(response.body.status, 'healthy');
   assert.equal(response.body.protocol_version, '2026-07-28');
   assert.equal(response.body.kommo_base_url, undefined);
+});
+
+test('readiness reports missing configuration without affecting liveness', async () => {
+  const app = createApp({ logLevel: 'silent' });
+  const response = await request(app).get('/ready').expect(503);
+  assert.equal(response.body.status, 'not_ready');
+  assert.ok(response.body.issues.some((issue) => issue.includes('KOMMO_ACCESS_TOKEN')));
+});
+
+test('runtime configuration requires a valid HTTPS URL and token', () => {
+  assert.deepEqual(validateRuntimeConfig({}), [
+    'KOMMO_BASE_URL is required',
+    'KOMMO_ACCESS_TOKEN is required',
+  ]);
+  assert.deepEqual(
+    validateRuntimeConfig({ KOMMO_BASE_URL: 'https://example.kommo.com', KOMMO_ACCESS_TOKEN: 'x' }),
+    [],
+  );
 });
 
 test('rejects legacy clients and advertises the modern protocol', async () => {

--- a/test/kommo-api.test.mjs
+++ b/test/kommo-api.test.mjs
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { KommoAPI, parseRetryAfter } from '../dist/kommo-api.js';
+
+async function withServer(context, handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  context.after(() => new Promise((resolve) => server.close(resolve)));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+test('Salesbot requests follow the documented v4 payloads', async (context) => {
+  const calls = [];
+  const baseUrl = await withServer(context, async (request, response) => {
+    calls.push({ method: request.method, url: request.url, body: await requestBody(request) });
+    response.writeHead(202).end();
+  });
+  const api = new KommoAPI({ baseUrl, accessToken: 'test', maxRetries: 0 });
+
+  assert.deepEqual(await api.runSalesbot(7, 42, 'leads'), { accepted: true });
+  assert.deepEqual(await api.stopSalesbot(7, 42, 'leads'), { accepted: true });
+  assert.deepEqual(calls, [
+    {
+      method: 'POST',
+      url: '/api/v4/bots/run',
+      body: [{ bot_id: 7, entity_id: 42, entity_type: 'leads' }],
+    },
+    {
+      method: 'POST',
+      url: '/api/v4/bots/7/stop',
+      body: { entity_id: 42, entity_type: 'leads' },
+    },
+  ]);
+});
+
+test('GET requests retry a 429 and honor Retry-After', async (context) => {
+  let attempts = 0;
+  const baseUrl = await withServer(context, (_request, response) => {
+    attempts += 1;
+    if (attempts === 1) {
+      response.writeHead(429, { 'Retry-After': '0' }).end();
+      return;
+    }
+    response.writeHead(200, { 'Content-Type': 'application/json' }).end('{"id":1,"name":"Conta"}');
+  });
+  const api = new KommoAPI({ baseUrl, accessToken: 'test', maxRetries: 1 });
+
+  assert.equal((await api.getAccount()).id, 1);
+  assert.equal(attempts, 2);
+  assert.equal(parseRetryAfter('2'), 2000);
+});
+
+test('pagination failures are propagated instead of returning partial totals', async (context) => {
+  const baseUrl = await withServer(context, (request, response) => {
+    const page = new URL(request.url, baseUrl).searchParams.get('page');
+    if (page === '1') {
+      response
+        .writeHead(200, { 'Content-Type': 'application/json' })
+        .end('{"_embedded":{"leads":[{"id":1}]},"_links":{"next":{"href":"next"}}}');
+      return;
+    }
+    response.writeHead(503).end();
+  });
+  const api = new KommoAPI({ baseUrl, accessToken: 'test', maxRetries: 0 });
+
+  await assert.rejects(
+    () => api.getAllLeads(),
+    (error) => error.response?.status === 503,
+  );
+});
+
+test('sales reports are calculated from documented leads, pipelines and users endpoints', async (context) => {
+  const paths = [];
+  const baseUrl = await withServer(context, (request, response) => {
+    const url = new URL(request.url, baseUrl);
+    paths.push(url.pathname);
+    response.setHeader('Content-Type', 'application/json');
+    if (url.pathname === '/api/v4/leads') {
+      response.end(
+        JSON.stringify({
+          _embedded: {
+            leads: [
+              {
+                id: 1,
+                name: 'Ganho',
+                price: 100,
+                status_id: 142,
+                pipeline_id: 3,
+                responsible_user_id: 5,
+                created_at: 1767225600,
+                updated_at: 1767225600,
+                created_by: 5,
+                closed_at: 1767225600,
+              },
+              {
+                id: 2,
+                name: 'Perdido',
+                price: 50,
+                status_id: 143,
+                pipeline_id: 3,
+                responsible_user_id: 5,
+                created_at: 1767225600,
+                updated_at: 1767225600,
+                created_by: 5,
+                closed_at: 1767225600,
+              },
+            ],
+          },
+        }),
+      );
+      return;
+    }
+    if (url.pathname === '/api/v4/leads/pipelines') {
+      response.end(JSON.stringify({ _embedded: { pipelines: [{ id: 3, name: 'Vendas' }] } }));
+      return;
+    }
+    if (url.pathname === '/api/v4/users') {
+      response.end(JSON.stringify({ _embedded: { users: [{ id: 5, name: 'Ana' }] } }));
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  const api = new KommoAPI({ baseUrl, accessToken: 'test', maxRetries: 0 });
+
+  const report = await api.getSalesReport('2026-01-01', '2026-01-31');
+  assert.equal(report.leads.won, 1);
+  assert.equal(report.leads.lost, 1);
+  assert.equal(report.revenue.total, 100);
+  assert.equal(report.revenue.conversion_rate, 50);
+  assert.ok(paths.every((path) => !path.includes('reports') && !path.includes('dashboard')));
+});

--- a/test/kommo-api.test.mjs
+++ b/test/kommo-api.test.mjs
@@ -84,6 +84,10 @@ test('sales reports are calculated from documented leads, pipelines and users en
     const url = new URL(request.url, baseUrl);
     paths.push(url.pathname);
     response.setHeader('Content-Type', 'application/json');
+    if (url.pathname === '/api/v4/account') {
+      response.end(JSON.stringify({ id: 1, name: 'Conta', timezone: 'UTC' }));
+      return;
+    }
     if (url.pathname === '/api/v4/leads') {
       response.end(
         JSON.stringify({
@@ -137,4 +141,58 @@ test('sales reports are calculated from documented leads, pipelines and users en
   assert.equal(report.revenue.total, 100);
   assert.equal(report.revenue.conversion_rate, 50);
   assert.ok(paths.every((path) => !path.includes('reports') && !path.includes('dashboard')));
+});
+
+test('sales reports use account timezone boundaries and reject impossible dates', async (context) => {
+  const baseUrl = await withServer(context, (request, response) => {
+    const url = new URL(request.url, baseUrl);
+    response.setHeader('Content-Type', 'application/json');
+    if (url.pathname === '/api/v4/account') {
+      response.end(JSON.stringify({ id: 1, name: 'Conta', timezone: 'America/Sao_Paulo' }));
+      return;
+    }
+    if (url.pathname === '/api/v4/leads') {
+      const lead = (id, createdAt) => ({
+        id,
+        name: `Lead ${id}`,
+        price: 100,
+        status_id: 142,
+        pipeline_id: 3,
+        responsible_user_id: 5,
+        created_at: createdAt,
+        updated_at: createdAt,
+        created_by: 5,
+        closed_at: createdAt,
+      });
+      response.end(
+        JSON.stringify({
+          _embedded: {
+            leads: [
+              lead(1, Date.parse('2026-01-01T02:59:59Z') / 1000),
+              lead(2, Date.parse('2026-01-01T03:00:00Z') / 1000),
+            ],
+          },
+        }),
+      );
+      return;
+    }
+    if (url.pathname === '/api/v4/leads/pipelines') {
+      response.end(JSON.stringify({ _embedded: { pipelines: [{ id: 3, name: 'Vendas' }] } }));
+      return;
+    }
+    if (url.pathname === '/api/v4/users') {
+      response.end(JSON.stringify({ _embedded: { users: [{ id: 5, name: 'Ana' }] } }));
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  const api = new KommoAPI({ baseUrl, accessToken: 'test', maxRetries: 0 });
+
+  const report = await api.getSalesReport('2026-01-01', '2026-01-01');
+  assert.equal(report.leads.total, 1);
+  assert.equal(report.leads.won, 1);
+  await assert.rejects(
+    () => api.getSalesReport('2026-02-31', '2026-03-01'),
+    /datas reais no formato YYYY-MM-DD/,
+  );
 });

--- a/test/official-client.test.mjs
+++ b/test/official-client.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { createApp } from '../dist/http-streamable.js';
 
-async function verifyDiscovery(url) {
+async function verifyDiscovery(url, createLeadCalls) {
   const client = new Client(
     { name: 'kommo-mcp-modern-test', version: '1.0.0' },
     { versionNegotiation: { mode: { pin: '2026-07-28' } } },
@@ -24,13 +24,50 @@ async function verifyDiscovery(url) {
     assert.equal(tools.length, 23);
     assert.equal(resources.length, 5);
     assert.equal(prompts.length, 4);
+    assert.equal(tools.find((tool) => tool.name === 'get_leads')?.annotations?.readOnlyHint, true);
+    assert.equal(
+      tools.find((tool) => tool.name === 'create_lead')?.annotations?.destructiveHint,
+      true,
+    );
+
+    const failedRead = await client.callTool({ name: 'get_account', arguments: {} });
+    assert.equal(failedRead.isError, true);
+    assert.equal(failedRead.content[0].text, 'Erro interno ao executar a tool.');
+    assert.doesNotMatch(failedRead.content[0].text, /sensitive-token/);
+
+    const blocked = await client.callTool({ name: 'create_lead', arguments: { name: 'Teste' } });
+    assert.equal(blocked.isError, true);
+    assert.match(blocked.content[0].text, /confirm=true/);
+
+    const created = await client.callTool({
+      name: 'create_lead',
+      arguments: { name: 'Teste', confirm: true },
+    });
+    assert.equal(created.isError, undefined);
+    assert.deepEqual(createLeadCalls, [{ name: 'Teste' }]);
   } finally {
     await client.close();
   }
 }
 
 test('official MCP client discovers capabilities with protocol 2026-07-28', async (context) => {
-  const server = createApp({ logLevel: 'silent' }).listen(0, '127.0.0.1');
+  const previousConfirmation = process.env.MCP_CONFIRM_WRITES;
+  process.env.MCP_CONFIRM_WRITES = 'true';
+  context.after(() => {
+    if (previousConfirmation === undefined) delete process.env.MCP_CONFIRM_WRITES;
+    else process.env.MCP_CONFIRM_WRITES = previousConfirmation;
+  });
+  const createLeadCalls = [];
+  const kommoAPI = {
+    async getAccount() {
+      throw new Error('sensitive-token');
+    },
+    async createLead(input) {
+      createLeadCalls.push(input);
+      return { id: 1, ...input };
+    },
+  };
+  const server = createApp({ logLevel: 'silent', kommoAPI }).listen(0, '127.0.0.1');
   await new Promise((resolve) => server.once('listening', resolve));
   context.after(() => new Promise((resolve) => server.close(resolve)));
 
@@ -38,5 +75,5 @@ test('official MCP client discovers capabilities with protocol 2026-07-28', asyn
   assert.ok(address && typeof address === 'object');
   const url = new URL(`http://127.0.0.1:${address.port}/mcp`);
 
-  await verifyDiscovery(url);
+  await verifyDiscovery(url, createLeadCalls);
 });

--- a/test/tool-handlers.test.mjs
+++ b/test/tool-handlers.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { executeTool } from '../dist/mcp/tool-handlers.js';
+import { MCP_TOOLS } from '../dist/mcp/tool-definitions.js';
 
 function resultData(result) {
   assert.equal(result.isError, undefined);
@@ -94,4 +95,47 @@ test('Kommo API failures are propagated to the transport error boundary', async 
   };
 
   await assert.rejects(() => executeTool(api, 'create_lead', { name: 'Teste' }), apiError);
+});
+
+test('every advertised tool has an executable handler', async () => {
+  const validArguments = {
+    get_account: {},
+    get_leads: {},
+    get_lead: { id: 1 },
+    create_lead: { name: 'Teste' },
+    update_lead: { id: 1, name: 'Teste' },
+    move_lead: { lead_id: 1, status_id: 142 },
+    get_pipelines: {},
+    get_sales_report: { dateFrom: '2026-01-01', dateTo: '2026-01-31' },
+    get_dashboard: {},
+    get_contacts: {},
+    get_companies: {},
+    get_tasks: {},
+    create_task: { text: 'Teste', entity_id: 1, entity_type: 'leads', complete_till: 1 },
+    get_users: {},
+    get_loss_reasons: {},
+    get_loss_reason: { id: 1 },
+    get_notes: { entity_type: 'leads', entity_id: 1 },
+    add_note: { entity_type: 'leads', entity_id: 1, text: 'Teste' },
+    pin_note: { entity_type: 'leads', note_id: 1 },
+    unpin_note: { entity_type: 'leads', note_id: 1 },
+    run_salesbot: { bot_id: 1, entity_id: 1, entity_type: 'leads' },
+    stop_salesbot: { bot_id: 1, entity_id: 1, entity_type: 'leads' },
+    ask_kommo: { question: 'ajuda' },
+  };
+  const api = new Proxy(
+    {},
+    {
+      get(_target, property) {
+        if (property === 'getAllLeads') return async () => [];
+        return async () => ({});
+      },
+    },
+  );
+
+  for (const tool of MCP_TOOLS) {
+    assert.ok(validArguments[tool.name], `missing fixture for ${tool.name}`);
+    const result = await executeTool(api, tool.name, validArguments[tool.name]);
+    assert.equal(result.isError, undefined, `${tool.name} returned an error`);
+  }
 });


### PR DESCRIPTION
## Resumo

Aplica o hardening funcional, operacional e de distribuição identificado após a migração integral para MCP `2026-07-28`.

## Correções funcionais

- corrige os payloads oficiais de iniciar e parar Salesbot;
- exige `bot_id`, `entity_id` e `entity_type=leads`;
- remove chamadas a endpoints analíticos sem documentação pública;
- reconstrói relatório de vendas e dashboard usando leads, pipelines, usuários e tarefas oficiais;
- corrige `ask_kommo` para contar vendas apenas no status ganho;
- interrompe paginação com erro em vez de retornar totais parciais.

## Resiliência e segurança

- timeout e retry configuráveis;
- backoff com jitter e suporte a `Retry-After`;
- retry automático somente em leituras, evitando duplicar escritas;
- erros MCP sanitizados sem detalhes sensíveis;
- endpoint `/ready` e validação obrigatória de URL/token no startup;
- annotations `readOnlyHint`, `destructiveHint` e `idempotentHint`;
- confirmação opcional de escrita via `MCP_CONFIRM_WRITES=true`.

## Testes e distribuição

- 18 testes automatizados;
- contratos HTTP reais para Salesbot, retry, paginação e relatórios;
- todas as 23 tools possuem handler exercitado;
- cliente MCP oficial valida annotations e confirmação;
- versão preparada para `3.0.0`;
- workflow de tag publica GHCR com SBOM/provenance;
- publicação npm opcional com provenance quando `NPM_TOKEN` estiver configurado;
- nome `kommo-mcp-server` verificado como disponível no npm em 2026-08-18.

## Validação local

- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm test` — 18/18
- `npm run audit:prod` — 0 vulnerabilidades
- `npm pack --dry-run`
- parse do workflow de release

## Pendências externas após o merge

- validação real com Cursor e Claude Desktop (#4);
- smoke test com uma conta Kommo de teste;
- configurar `NPM_TOKEN` se a publicação npm for desejada;
- criar a tag `v3.0.0` somente após essas validações.
