### PR TITLE
feat: prepara release comunitária v3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Miguelgbastos

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,17 @@ jobs:
       - name: Tests
         run: npm test
 
+      - name: Coverage threshold
+        run: npm run test:coverage
+
       - name: Production dependency audit
         run: npm run audit:prod
 
       - name: Build
         run: npm run build
+
+      - name: Validate npm package contents
+        run: npm pack --dry-run
 
   docker:
     name: Docker build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,10 @@ jobs:
       - name: Verify tag matches package version
         run: test "v$(node -p "require('./package.json').version")" = "$GITHUB_REF_NAME"
 
+      - name: Require npm publishing credentials
+        run: test -n "$NODE_AUTH_TOKEN"
+
       - name: Publish npm with provenance
-        if: ${{ env.NODE_AUTH_TOKEN != '' }}
         run: npm publish --provenance --access public
 
       - name: Login to GitHub Container Registry
@@ -42,12 +44,14 @@ jobs:
         run: |
           image="ghcr.io/${GITHUB_REPOSITORY,,}"
           version="${GITHUB_REF_NAME#v}"
+          minor="${version%.*}"
           docker buildx create --use
           docker buildx build \
             --push \
             --provenance=true \
             --sbom=true \
             --tag "$image:$version" \
+            --tag "$image:$minor" \
             --tag "$image:latest" \
             .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - Anotações MCP de risco e confirmação opcional para operações de escrita.
 - Testes de contrato HTTP da API Kommo e cobertura de todas as tools anunciadas.
 - Workflow de release para imagem GHCR com SBOM/provenance e publicação npm opcional.
+- Transporte local `stdio` e executável `kommo-mcp-server` para instalação npm.
+- Compatibilidade stateless com clientes MCP da família 2025.
+- Limitador coordenado de requisições ao Kommo por processo.
+- Cobertura do código de produção medida no CI com pisos explícitos para
+  linhas, branches e funções, compatíveis com Node 20 e 22.
 
 ### Modificado
 
@@ -40,7 +45,8 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
   volta a proibir `any` em todo código-fonte.
 - Instruções atuais para conectores remotos do Claude Desktop.
 - Servidor migrado integralmente para o SDK MCP oficial v2 e para a revisão
-  `2026-07-28`; clientes legados agora são rejeitados explicitamente.
+  `2026-07-28`, preservando compatibilidade stateless com clientes da família 2025.
+- Release passa a exigir credenciais npm e publica tags Docker exatas, minor e `latest`.
 - Versão preparada para `3.0.0` devido à quebra de compatibilidade do protocolo.
 - Relatórios e dashboard passaram a ser calculados com endpoints públicos
   documentados de leads, pipelines, usuários e tarefas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ npm run dev        # executa via ts-node
 npm start          # executa o servidor compilado
 npm run typecheck  # apenas verificação de tipos
 npm test           # build e testes automatizados
+npm run test:coverage # cobertura mínima do código de produção
 npm run audit:prod # vulnerabilidades de produção
 ```
 
@@ -101,6 +102,7 @@ src/
 ├── kommo-api.ts          # Cliente HTTP da API Kommo
 ├── ask-kommo.ts          # Lógica conversacional do tool ask_kommo
 ├── http-streamable.ts    # Servidor MCP HTTP (Streamable HTTP)
+├── stdio.ts              # Servidor MCP local por stdin/stdout
 └── mcp/
     ├── server.ts             # Registro oficial de tools/resources/prompts
     ├── types.ts             # Tipos internos do MCP

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,15 @@ O projeto usa Versionamento Semântico e mantém as mudanças em `CHANGELOG.md`.
 Uma release deve possuir tag assinada ou verificável, notas de versão, CI verde
 e instruções para qualquer migração necessária.
 
+Antes de criar uma tag `v*`:
+
+1. valide a matriz em `docs/COMPATIBILITY.md` com uma conta Kommo de teste;
+2. confirme que a versão da tag coincide com `package.json`;
+3. configure `NPM_TOKEN` no ambiente Actions — a release falha se ele estiver ausente;
+4. execute `npm pack --dry-run` e revise o conteúdo do pacote;
+5. confirme a publicação npm, as tags GHCR exata/minor/latest e o SBOM;
+6. execute um smoke test instalando os artefatos publicados do zero.
+
 ## Decisões e segurança
 
 Decisões públicas ocorrem em Issues e Discussions. Vulnerabilidades seguem o

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,47 @@
+# Kommo MCP Server
+
+An open-source Model Context Protocol server for Kommo CRM. It exposes 23 tools,
+5 resources and 4 prompts for leads, contacts, companies, tasks, pipelines,
+reports, notes, Salesbot and loss reasons.
+
+The server supports MCP `2026-07-28`, stateless compatibility with the 2025
+protocol family, Streamable HTTP and local stdio.
+
+## Local installation
+
+Requires Node.js 20 or newer.
+
+```bash
+npm install -g kommo-mcp-server@3.0.0
+```
+
+Configure your MCP client to run:
+
+```json
+{
+  "mcpServers": {
+    "kommo": {
+      "command": "kommo-mcp-server",
+      "env": {
+        "KOMMO_BASE_URL": "https://your-account.kommo.com",
+        "KOMMO_ACCESS_TOKEN": "your-token"
+      }
+    }
+  }
+}
+```
+
+For Docker, remote HTTP deployment, the complete tool catalog and security
+guidance, read the [Portuguese documentation](README.md).
+
+## Safety
+
+Remote deployments require an MCP authentication token and TLS termination.
+Set `MCP_CONFIRM_WRITES=true` to require explicit confirmation for tools that
+modify CRM data. API calls are coordinated at no more than six requests per
+second per process, and write requests are never retried automatically.
+
+See [SECURITY.md](SECURITY.md) for private vulnerability reporting and
+[CONTRIBUTING.md](CONTRIBUTING.md) to contribute.
+
+MIT licensed.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kommo MCP Server
 
+[English documentation](README.en.md)
+
 [![CI](https://github.com/Miguelgbastos/Kommo-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/Miguelgbastos/Kommo-MCP/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](package.json)
@@ -38,8 +40,10 @@ Desktop, etc.).
 
 ## Funcionalidades
 
-- **MCP moderno**: revisão `2026-07-28` pelo SDK oficial, sem camada de
-  compatibilidade legada
+- **MCP moderno e compatível**: revisão `2026-07-28` pelo SDK oficial, com
+  compatibilidade stateless para clientes da família 2025
+- **Dois transportes oficiais**: Streamable HTTP para serviços remotos e
+  `stdio` para clientes locais
 - **23 tools**: leads, contatos, empresas, tarefas, pipelines, notas,
   relatórios, dashboard, Salesbot, motivos de perda
 - **5 resources**: relatório de vendas, pipelines, motivos de perda,
@@ -87,19 +91,20 @@ O servidor sobe em `http://127.0.0.1:3001/mcp`.
 
 ### Variáveis de ambiente
 
-| Variável              | Descrição                                                    | Default     |
-| --------------------- | ------------------------------------------------------------ | ----------- |
-| `KOMMO_BASE_URL`      | URL da conta Kommo (`https://<subdominio>.kommo.com`)        | —           |
-| `KOMMO_ACCESS_TOKEN`  | Token de acesso (integração privada ou OAuth2)               | —           |
-| `KOMMO_TIMEOUT_MS`    | Timeout de cada requisição ao Kommo                          | `15000`     |
-| `KOMMO_MAX_RETRIES`   | Retentativas de leituras em `429`/`5xx`                      | `3`         |
-| `KOMMO_TIMEZONE`      | Fuso IANA dos relatórios; por padrão usa o fuso da conta     | conta Kommo |
-| `PORT`                | Porta HTTP do servidor MCP                                   | `3001`      |
-| `MCP_HOST`            | Host de binding                                              | `127.0.0.1` |
-| `MCP_ALLOWED_ORIGINS` | Origens permitidas (separadas por vírgula)                   | —           |
-| `MCP_AUTH_TOKEN`      | Protege `/mcp`; obrigatório quando `MCP_HOST` não é loopback | —           |
-| `MCP_CONFIRM_WRITES`  | Exige `confirm=true` nas tools que alteram dados             | `false`     |
-| `LOG_LEVEL`           | Nível de log                                                 | `info`      |
+| Variável                    | Descrição                                                    | Default     |
+| --------------------------- | ------------------------------------------------------------ | ----------- |
+| `KOMMO_BASE_URL`            | URL da conta Kommo (`https://<subdominio>.kommo.com`)        | —           |
+| `KOMMO_ACCESS_TOKEN`        | Token de acesso (integração privada ou OAuth2)               | —           |
+| `KOMMO_TIMEOUT_MS`          | Timeout de cada requisição ao Kommo                          | `15000`     |
+| `KOMMO_MAX_RETRIES`         | Retentativas de leituras em `429`/`5xx`                      | `3`         |
+| `KOMMO_REQUESTS_PER_SECOND` | Limite coordenado de chamadas por processo (máximo 6)        | `6`         |
+| `KOMMO_TIMEZONE`            | Fuso IANA dos relatórios; por padrão usa o fuso da conta     | conta Kommo |
+| `PORT`                      | Porta HTTP do servidor MCP                                   | `3001`      |
+| `MCP_HOST`                  | Host de binding                                              | `127.0.0.1` |
+| `MCP_ALLOWED_ORIGINS`       | Origens permitidas (separadas por vírgula)                   | —           |
+| `MCP_AUTH_TOKEN`            | Protege `/mcp`; obrigatório quando `MCP_HOST` não é loopback | —           |
+| `MCP_CONFIRM_WRITES`        | Exige `confirm=true` nas tools que alteram dados             | `false`     |
+| `LOG_LEVEL`                 | Nível de log                                                 | `info`      |
 
 ## Execução
 
@@ -110,6 +115,13 @@ npm install
 npm run dev        # ts-node
 # ou
 npm run build && npm start
+```
+
+**Cliente local via stdio:**
+
+```bash
+npm run build
+npm run start:stdio
 ```
 
 **Docker:**
@@ -136,6 +148,25 @@ docker run -d -p 3001:3001 \
 
 ### Cursor
 
+Para execução local por `stdio`, adicione ao `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "kommo": {
+      "command": "npx",
+      "args": ["-y", "kommo-mcp-server@3.0.0"],
+      "env": {
+        "KOMMO_BASE_URL": "https://seu-dominio.kommo.com",
+        "KOMMO_ACCESS_TOKEN": "seu-token-aqui"
+      }
+    }
+  }
+}
+```
+
+Para o servidor HTTP:
+
 Adicione ao arquivo `~/.cursor/mcp.json` (ou nas configurações do projeto em
 `.cursor/mcp.json`):
 
@@ -155,9 +186,9 @@ Para uma implantação remota com HTTPS, abra **Settings → Connectors → Add
 connector** e informe a URL pública do endpoint, por exemplo
 `https://mcp.seudominio.com/mcp`.
 
-O Claude Desktop não conecta servidores HTTP remotos configurados diretamente
-em `claude_desktop_config.json`. Esse arquivo é destinado a servidores locais
-executados como processos; o Kommo MCP oferece atualmente transporte HTTP.
+Para execução local, use a mesma configuração `command`/`args`/`env` acima no
+`claude_desktop_config.json`. Servidores HTTP remotos devem ser adicionados
+pela tela de Connectors.
 
 ## Endpoints
 
@@ -253,6 +284,7 @@ src/
 ├── kommo-api.ts             # Cliente da API Kommo
 ├── ask-kommo.ts             # Lógica conversacional ask_kommo
 ├── http-streamable.ts       # Servidor MCP HTTP
+├── stdio.ts                 # Servidor MCP local por stdin/stdout
 └── mcp/
     ├── server.ts            # Definição oficial do servidor MCP
     ├── types.ts             # Tipos MCP
@@ -282,8 +314,8 @@ await client.connect(transport);
 const { tools } = await client.listTools();
 ```
 
-Clientes limitados ao lifecycle MCP de 2024/2025 recebem o erro
-`-32022 Unsupported protocol version` e precisam ser atualizados.
+Clientes da família 2025 são atendidos automaticamente pelo modo stateless.
+Clientes modernos podem fixar `2026-07-28` conforme o exemplo acima.
 
 ## Troubleshooting
 
@@ -297,8 +329,9 @@ Clientes limitados ao lifecycle MCP de 2024/2025 recebem o erro
   enviar `Authorization: Bearer <token>` ou `X-API-Key: <token>`.
 - **`503` no `/ready`** — configure `KOMMO_BASE_URL` com HTTPS e defina
   `KOMMO_ACCESS_TOKEN` antes de iniciar o serviço real.
-- **`429` do Kommo** — leituras são repetidas com backoff e `Retry-After`;
-  escritas não são repetidas automaticamente para evitar duplicidade.
+- **`429` do Kommo** — todas as chamadas compartilham um limitador coordenado;
+  leituras usam backoff e `Retry-After`, enquanto escritas não são repetidas
+  automaticamente para evitar duplicidade.
 - **Docker `HEALTHCHECK` falha** — a imagem usa `node --eval` para o
   healthcheck, verifique se a porta interna corresponde a `PORT`.
 - **Erros de build TypeScript** — rode `npm run typecheck` para ver mensagens
@@ -315,17 +348,19 @@ Clientes limitados ao lifecycle MCP de 2024/2025 recebem o erro
 - [CHANGELOG.md](CHANGELOG.md) deste projeto
 - [ROADMAP.md](ROADMAP.md) — prioridades e oportunidades de contribuição
 - [MAINTAINERS.md](MAINTAINERS.md) — manutenção, revisão e releases
+- [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) — matriz automatizada e
+  checklist de validação manual em clientes MCP
 
 ## Compatibilidade e suporte
 
-| Componente     | Suporte atual                                  |
-| -------------- | ---------------------------------------------- |
-| Node.js        | 20 e 22                                        |
-| Protocolo MCP  | somente `2026-07-28`                           |
-| Transporte     | Streamable HTTP oficial; respostas JSON ou SSE |
-| Cursor         | Configuração HTTP documentada                  |
-| Claude Desktop | Conector remoto via Settings → Connectors      |
-| Instalação     | Git/Docker; ainda não publicado no npm         |
+| Componente     | Suporte atual                          |
+| -------------- | -------------------------------------- |
+| Node.js        | 20 e 22                                |
+| Protocolo MCP  | `2026-07-28` e família 2025 stateless  |
+| Transporte     | Streamable HTTP e stdio oficiais       |
+| Cursor         | stdio local ou HTTP                    |
+| Claude Desktop | stdio local ou conector remoto         |
+| Instalação     | Git, Docker e pacote npm na release v3 |
 
 Suporte comunitário ocorre por Issues e Discussions, sem garantia de tempo de
 resposta. Veja as responsabilidades em [MAINTAINERS.md](MAINTAINERS.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,12 +6,13 @@ Este roadmap orienta contribuições; não representa compromisso de prazo.
 
 - Validar Cursor e Claude Desktop de ponta a ponta e registrar versões testadas.
 - Validar a revisão MCP `2026-07-28` com mais clientes da comunidade.
+- Validar o transporte `stdio` e a compatibilidade stateless da família 2025.
 - Publicar a release `v3.0.0` após validação em uma conta Kommo de teste.
 
 ## Próximo
 
-- Adicionar transporte `stdio` para clientes locais.
-- Publicar o pacote no npm após validar nome, conteúdo e provenance.
+- Publicar o pacote no npm e a imagem no GHCR após validar conteúdo e provenance.
+- Adicionar cobertura automatizada e smoke test da imagem publicada.
 
 ## Futuro
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,26 @@
+# Matriz de compatibilidade
+
+Esta matriz separa evidência automatizada de validação manual em clientes finais.
+
+| Cliente / transporte | Protocolo | Estado | Evidência |
+| --- | --- | --- | --- |
+| SDK TypeScript oficial / HTTP | `2026-07-28` | Automatizado | descoberta, tools, resources, prompts e confirmação de escrita |
+| SDK TypeScript oficial / HTTP | família 2025 | Automatizado | inicialização stateless e execução de tools |
+| SDK TypeScript oficial / stdio | família 2025 | Automatizado | processo local, inicialização e `tools/list` |
+| Cursor / stdio | automático | Pendente manual | requer versão do cliente, SO e conta Kommo de teste |
+| Cursor / HTTP | automático | Pendente manual | requer versão do cliente, SO e conta Kommo de teste |
+| Claude Desktop / stdio | automático | Pendente manual | requer versão do cliente, SO e conta Kommo de teste |
+| Claude Desktop / conector remoto | automático | Pendente manual | requer endpoint HTTPS e conta Kommo de teste |
+
+## Checklist manual para uma release
+
+Registre cliente, versão, sistema operacional, commit testado e transporte. Para
+cada combinação suportada, valide:
+
+1. conexão e negociação do protocolo;
+2. `tools/list`, `resources/list` e `prompts/list`;
+3. uma tool somente leitura contra uma conta de teste;
+4. uma escrita não destrutiva com confirmação explícita;
+5. ausência de tokens e dados pessoais nos logs e mensagens de erro.
+
+Testes automatizados do SDK não substituem essa evidência em produtos finais.

--- a/env.example
+++ b/env.example
@@ -3,6 +3,8 @@ KOMMO_BASE_URL=https://seu-dominio.kommo.com
 KOMMO_ACCESS_TOKEN=seu-token-aqui
 KOMMO_TIMEOUT_MS=15000
 KOMMO_MAX_RETRIES=3
+# Limite coordenado por processo; mantenha em no máximo 6 req/s
+KOMMO_REQUESTS_PER_SECOND=6
 # Opcional: sobrescreve o fuso informado pela conta Kommo (formato IANA)
 # KOMMO_TIMEZONE=America/Sao_Paulo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "express": "^5.2.1",
         "zod": "^4.2.0"
       },
+      "bin": {
+        "kommo-mcp-server": "dist/stdio.js"
+      },
       "devDependencies": {
         "@modelcontextprotocol/client": "^2.0.0",
         "@types/cors": "^2.8.19",
@@ -25,6 +28,7 @@
         "@types/supertest": "^6.0.3",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
+        "c8": "^10.1.3",
         "eslint": "^8.57.0",
         "prettier": "^3.3.3",
         "supertest": "^7.1.4",
@@ -33,6 +37,16 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -232,6 +246,119 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -383,6 +510,17 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -474,6 +612,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true,
       "license": "MIT"
     },
@@ -980,6 +1125,40 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/c8": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
+      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^7.0.1",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1034,6 +1213,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -1104,6 +1298,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1280,10 +1481,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1336,6 +1551,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1817,6 +2042,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -1881,6 +2123,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2094,6 +2346,13 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2215,6 +2474,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2259,6 +2528,61 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.9",
@@ -2353,6 +2677,29 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -2477,6 +2824,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2586,6 +2943,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2635,6 +2999,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2795,6 +3176,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3066,6 +3457,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3085,7 +3489,52 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3158,6 +3607,98 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/text-table": {
@@ -3371,6 +3912,32 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3405,10 +3972,86 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,18 @@
   "version": "3.0.0",
   "description": "MCP (Model Context Protocol) Server for Kommo CRM integration — expõe tools, resources e prompts para clientes MCP como Cursor e Claude.",
   "main": "dist/http-streamable.js",
+  "bin": {
+    "kommo-mcp-server": "dist/stdio.js"
+  },
   "type": "module",
   "scripts": {
     "clean": "node --eval \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "npm run clean && tsc",
     "start": "node dist/http-streamable.js",
+    "start:stdio": "node dist/stdio.js",
     "dev": "ts-node --esm src/http-streamable.ts",
     "test": "npm run build && node --test test/*.test.mjs",
+    "test:coverage": "npm run build && c8 --check-coverage --lines 70 --branches 60 --functions 45 --include='dist/**/*.js' node --test test/*.test.mjs",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test && npm run audit:prod",
     "audit:prod": "npm audit --omit=dev --audit-level=high",
     "typecheck": "tsc --noEmit",
@@ -48,6 +53,7 @@
   "files": [
     "dist",
     "README.md",
+    "README.en.md",
     "LICENSE",
     "env.example"
   ],
@@ -68,6 +74,7 @@
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "c8": "^10.1.3",
     "eslint": "^8.57.0",
     "prettier": "^3.3.3",
     "supertest": "^7.1.4",

--- a/src/http-streamable.ts
+++ b/src/http-streamable.ts
@@ -35,6 +35,12 @@ export function validateRuntimeConfig(env: NodeJS.ProcessEnv = process.env): str
     }
   }
   if (!env.KOMMO_ACCESS_TOKEN) issues.push('KOMMO_ACCESS_TOKEN is required');
+  if (env.KOMMO_REQUESTS_PER_SECOND) {
+    const requestsPerSecond = Number(env.KOMMO_REQUESTS_PER_SECOND);
+    if (!Number.isFinite(requestsPerSecond) || requestsPerSecond <= 0 || requestsPerSecond > 6) {
+      issues.push('KOMMO_REQUESTS_PER_SECOND must be greater than 0 and at most 6');
+    }
+  }
   if (env.KOMMO_TIMEZONE) {
     try {
       new Intl.DateTimeFormat('en-US', { timeZone: env.KOMMO_TIMEZONE }).format();
@@ -87,6 +93,7 @@ export function createApp(options: AppOptions = {}) {
       timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS) || 15_000,
       maxRetries: Number(process.env.KOMMO_MAX_RETRIES) || 3,
       timezone: process.env.KOMMO_TIMEZONE,
+      requestsPerSecond: Number(process.env.KOMMO_REQUESTS_PER_SECOND) || 6,
     });
   const logger = {
     error: (message: string, error?: unknown) => {
@@ -104,7 +111,7 @@ export function createApp(options: AppOptions = {}) {
   }
 
   const mcpHandler = createMcpHandler(() => createKommoMcpServer(kommoAPI), {
-    legacy: 'reject',
+    legacy: 'stateless',
     onerror: (error) => logger.error('MCP request failed', error),
   });
   const nodeHandler = toNodeHandler(mcpHandler, {
@@ -134,6 +141,7 @@ export function createApp(options: AppOptions = {}) {
       timestamp: new Date().toISOString(),
       version: SERVER_VERSION,
       protocol_version: MODERN_MCP_PROTOCOL_VERSION,
+      legacy_protocol_compatibility: true,
       tools_count: MCP_TOOLS.length,
       resources_count: MCP_RESOURCES.length,
       prompts_count: MCP_PROMPTS.length,

--- a/src/kommo-api.ts
+++ b/src/kommo-api.ts
@@ -6,6 +6,7 @@ export interface KommoConfig {
   timeoutMs?: number;
   maxRetries?: number;
   timezone?: string;
+  requestsPerSecond?: number;
 }
 
 interface CalendarDate {
@@ -102,6 +103,15 @@ function zonedCalendarDate(instant: Date, timezone: string): CalendarDate {
 interface RetryableRequestConfig extends InternalAxiosRequestConfig {
   retryCount?: number;
 }
+
+interface RateLimitState {
+  queue: Promise<void>;
+  nextRequestAt: number;
+  cooldownUntil: number;
+  minimumIntervalMs: number;
+}
+
+const rateLimitStates = new Map<string, RateLimitState>();
 
 export function parseRetryAfter(value: unknown, now = Date.now()): number | undefined {
   if (typeof value !== 'string' && typeof value !== 'number') return undefined;
@@ -312,11 +322,29 @@ export interface KommoDashboardData {
 export class KommoAPI {
   private client: AxiosInstance;
   private configuredTimezone?: string;
+  private rateLimitState: RateLimitState;
 
   constructor(config: KommoConfig) {
     if (config.timezone) assertTimezone(config.timezone);
     this.configuredTimezone = config.timezone;
     const maxRetries = config.maxRetries ?? 3;
+    const requestsPerSecond = config.requestsPerSecond ?? 6;
+    if (!Number.isFinite(requestsPerSecond) || requestsPerSecond <= 0 || requestsPerSecond > 6) {
+      throw new Error('requestsPerSecond must be greater than 0 and at most 6');
+    }
+    const minimumIntervalMs = Math.ceil(1_000 / requestsPerSecond);
+    const existingRateLimitState = rateLimitStates.get(config.baseUrl);
+    this.rateLimitState = existingRateLimitState ?? {
+      queue: Promise.resolve(),
+      nextRequestAt: 0,
+      cooldownUntil: 0,
+      minimumIntervalMs,
+    };
+    this.rateLimitState.minimumIntervalMs = Math.max(
+      this.rateLimitState.minimumIntervalMs,
+      minimumIntervalMs,
+    );
+    rateLimitStates.set(config.baseUrl, this.rateLimitState);
     this.client = axios.create({
       baseURL: config.baseUrl,
       timeout: config.timeoutMs ?? 15_000,
@@ -324,6 +352,18 @@ export class KommoAPI {
         Authorization: `Bearer ${config.accessToken}`,
         'Content-Type': 'application/json',
       },
+    });
+    this.client.interceptors.request.use(async (request) => {
+      const scheduled = this.rateLimitState.queue.then(async () => {
+        const waitMs =
+          Math.max(0, this.rateLimitState.nextRequestAt, this.rateLimitState.cooldownUntil) -
+          Date.now();
+        if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
+        this.rateLimitState.nextRequestAt = Date.now() + this.rateLimitState.minimumIntervalMs;
+      });
+      this.rateLimitState.queue = scheduled.catch(() => undefined);
+      await scheduled;
+      return request;
     });
     this.client.interceptors.response.use(undefined, async (error: unknown) => {
       if (!axios.isAxiosError(error) || !error.config) throw error;
@@ -333,12 +373,18 @@ export class KommoAPI {
       const retryableMethod = ['GET', 'HEAD', 'OPTIONS'].includes(method);
       const retryableFailure =
         status === 429 || status === 502 || status === 503 || status === 504 || !error.response;
+      const retryAfter = error.response?.headers['retry-after'];
+      const retryAfterMs = parseRetryAfter(retryAfter);
+      if (status === 429 && retryAfterMs !== undefined) {
+        this.rateLimitState.cooldownUntil = Math.max(
+          this.rateLimitState.cooldownUntil,
+          Date.now() + retryAfterMs,
+        );
+      }
       request.retryCount = request.retryCount ?? 0;
       if (!retryableMethod || !retryableFailure || request.retryCount >= maxRetries) throw error;
 
       request.retryCount += 1;
-      const retryAfter = error.response?.headers['retry-after'];
-      const retryAfterMs = parseRetryAfter(retryAfter);
       const backoffMs = Math.min(250 * 2 ** (request.retryCount - 1), 4_000);
       const jitterMs = Math.floor(Math.random() * 100);
       await new Promise((resolve) => setTimeout(resolve, retryAfterMs ?? backoffMs + jitterMs));

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { KommoAPI } from './kommo-api.js';
+import { createKommoMcpServer } from './mcp/server.js';
+import { validateRuntimeConfig } from './http-streamable.js';
+
+dotenv.config();
+
+export function startStdioServer() {
+  const configIssues = validateRuntimeConfig();
+  if (configIssues.length > 0) throw new Error(configIssues.join('; '));
+
+  const kommoAPI = new KommoAPI({
+    baseUrl: process.env.KOMMO_BASE_URL!,
+    accessToken: process.env.KOMMO_ACCESS_TOKEN!,
+    timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS) || 15_000,
+    maxRetries: Number(process.env.KOMMO_MAX_RETRIES) || 3,
+    timezone: process.env.KOMMO_TIMEZONE,
+    requestsPerSecond: Number(process.env.KOMMO_REQUESTS_PER_SECOND) || 6,
+  });
+
+  return serveStdio(() => createKommoMcpServer(kommoAPI), {
+    legacy: 'serve',
+    onerror: (error) => console.error(`[${new Date().toISOString()}] MCP stdio error`, error),
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) startStdioServer();

--- a/test/http-streamable.test.mjs
+++ b/test/http-streamable.test.mjs
@@ -43,17 +43,24 @@ test('runtime configuration requires a valid HTTPS URL and token', () => {
     validateRuntimeConfig({ KOMMO_BASE_URL: 'https://example.kommo.com', KOMMO_ACCESS_TOKEN: 'x' }),
     [],
   );
+  assert.deepEqual(
+    validateRuntimeConfig({
+      KOMMO_BASE_URL: 'https://example.kommo.com',
+      KOMMO_ACCESS_TOKEN: 'x',
+      KOMMO_REQUESTS_PER_SECOND: '7',
+    }),
+    ['KOMMO_REQUESTS_PER_SECOND must be greater than 0 and at most 6'],
+  );
 });
 
-test('rejects legacy clients and advertises the modern protocol', async () => {
+test('serves 2025-era clients through stateless compatibility', async () => {
   const app = createApp({ logLevel: 'silent' });
   const response = await request(app)
     .post('/mcp')
     .set('Accept', accept)
     .send(legacyInitialize())
-    .expect(400);
-  assert.equal(response.body.error.code, -32022);
-  assert.deepEqual(response.body.error.data.supported, ['2026-07-28']);
+    .expect(200);
+  assert.match(response.text, /2025-11-25/);
 });
 
 test('rejects non-JSON MCP requests', async () => {
@@ -79,5 +86,5 @@ test('blocks untrusted browser origins and enforces configured auth', async () =
     .set('Accept', accept)
     .set('Authorization', 'Bearer test-secret')
     .send(payload)
-    .expect(400);
+    .expect(200);
 });

--- a/test/kommo-api.test.mjs
+++ b/test/kommo-api.test.mjs
@@ -59,6 +59,31 @@ test('GET requests retry a 429 and honor Retry-After', async (context) => {
   assert.equal(parseRetryAfter('2'), 2000);
 });
 
+test('coordinates concurrent requests below the configured process rate', async (context) => {
+  const receivedAt = [];
+  const baseUrl = await withServer(context, (_request, response) => {
+    receivedAt.push(Date.now());
+    response.writeHead(200, { 'Content-Type': 'application/json' }).end('{"id":1,"name":"Conta"}');
+  });
+  const firstApi = new KommoAPI({
+    baseUrl,
+    accessToken: 'test',
+    maxRetries: 0,
+    requestsPerSecond: 5,
+  });
+  const secondApi = new KommoAPI({
+    baseUrl,
+    accessToken: 'test',
+    maxRetries: 0,
+    requestsPerSecond: 5,
+  });
+
+  await Promise.all([firstApi.getAccount(), secondApi.getAccount()]);
+
+  assert.equal(receivedAt.length, 2);
+  assert.ok(receivedAt[1] - receivedAt[0] >= 180);
+});
+
 test('pagination failures are propagated instead of returning partial totals', async (context) => {
   const baseUrl = await withServer(context, (request, response) => {
     const page = new URL(request.url, baseUrl).searchParams.get('page');

--- a/test/official-client.test.mjs
+++ b/test/official-client.test.mjs
@@ -3,16 +3,17 @@ import assert from 'node:assert/strict';
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { createApp } from '../dist/http-streamable.js';
 
-async function verifyDiscovery(url, createLeadCalls) {
+async function verifyDiscovery(url, createLeadCalls, versionNegotiation) {
+  const initialCreateLeadCalls = createLeadCalls.length;
   const client = new Client(
     { name: 'kommo-mcp-modern-test', version: '1.0.0' },
-    { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    versionNegotiation ? { versionNegotiation } : undefined,
   );
   const transport = new StreamableHTTPClientTransport(url);
 
   try {
     await client.connect(transport);
-    assert.equal(client.getProtocolEra(), 'modern');
+    assert.equal(client.getProtocolEra(), versionNegotiation ? 'modern' : 'legacy');
     assert.equal(client.getServerVersion()?.name, 'kommo-mcp-server');
 
     const [{ tools }, { resources }, { prompts }] = await Promise.all([
@@ -44,7 +45,8 @@ async function verifyDiscovery(url, createLeadCalls) {
       arguments: { name: 'Teste', confirm: true },
     });
     assert.equal(created.isError, undefined);
-    assert.deepEqual(createLeadCalls, [{ name: 'Teste' }]);
+    assert.equal(createLeadCalls.length, initialCreateLeadCalls + 1);
+    assert.deepEqual(createLeadCalls.at(-1), { name: 'Teste' });
   } finally {
     await client.close();
   }
@@ -75,5 +77,6 @@ test('official MCP client discovers capabilities with protocol 2026-07-28', asyn
   assert.ok(address && typeof address === 'object');
   const url = new URL(`http://127.0.0.1:${address.port}/mcp`);
 
+  await verifyDiscovery(url, createLeadCalls, { mode: { pin: '2026-07-28' } });
   await verifyDiscovery(url, createLeadCalls);
 });

--- a/test/stdio.test.mjs
+++ b/test/stdio.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+
+test('stdio transport serves local MCP clients', async () => {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ['dist/stdio.js'],
+    env: {
+      ...process.env,
+      KOMMO_BASE_URL: 'https://example.kommo.com',
+      KOMMO_ACCESS_TOKEN: 'test-token',
+      LOG_LEVEL: 'silent',
+    },
+  });
+  const client = new Client({ name: 'stdio-test', version: '1.0.0' });
+
+  try {
+    await client.connect(transport);
+    assert.equal(client.getProtocolEra(), 'legacy');
+    const { tools } = await client.listTools();
+    assert.equal(tools.length, 23);
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
## Objetivo

Finaliza os ajustes prioritários para transformar a versão 3 em uma distribuição comunitária instalável, compatível e verificável.

## Principais mudanças

- adiciona transporte local `stdio` e executável para publicação npm
- preserva MCP `2026-07-28` com compatibilidade stateless para clientes da família 2025
- coordena chamadas ao Kommo em até 6 req/s por conta e processo, incluindo cooldown compartilhado após `429`
- endurece o workflow de release: npm obrigatório, provenance, SBOM e tags GHCR exata/minor/latest
- adiciona cobertura mínima do código de produção ao CI
- inclui matriz de compatibilidade, documentação em inglês, CODEOWNERS e Dependabot
- atualiza README, changelog, roadmap e checklist de release

## Validação local

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` — 21/21
- `npm run test:coverage`
- cobertura também validada em Node 20
- `npm run audit:prod` — 0 vulnerabilidades
- `npm pack --dry-run`

O build Docker fica sob validação do job dedicado do GitHub Actions, pois Docker não está disponível no ambiente local.

## Gate manual antes da tag v3.0.0

A matriz real de Cursor/Claude Desktop com uma conta Kommo de teste permanece explicitamente pendente em `docs/COMPATIBILITY.md` e na issue #4. Este PR não publica a tag nem o pacote npm.