### PR TITLE
chore: concluir preparação segura da release v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.x', '22.x']
+        node-version: ['22.13.0', '24.x']
 
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4c0873ef8656cb3c50b3f42fb63bc1ade0cfa827 # v4
+        with:
+          languages: javascript-typescript
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@4c0873ef8656cb3c50b3f42fb63bc1ade0cfa827 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,48 +4,93 @@ on:
   push:
     tags: ['v*']
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  contents: read
 
 jobs:
-  publish:
+  validate:
+    name: Validate release
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Verify tag matches package version
+        run: test "v$(node -p "require('./package.json').version")" = "$GITHUB_REF_NAME"
+      - name: Install dependencies
+        run: npm ci
+      - name: Validate source and package
+        run: |
+          npm run typecheck
+          npm run lint
+          npm run format:check
+          npm test
+          npm run test:coverage
+          npm run audit:prod
+          npm pack --dry-run
+
+  publish-npm:
+    name: Publish npm package
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
           cache: npm
-
-      - name: Install and validate
-        run: npm ci && npm test && npm run audit:prod && npm pack --dry-run
-
-      - name: Verify tag matches package version
-        run: test "v$(node -p "require('./package.json').version")" = "$GITHUB_REF_NAME"
-
+      - name: Install dependencies
+        run: npm ci
       - name: Require npm publishing credentials
         run: test -n "$NODE_AUTH_TOKEN"
-
       - name: Publish npm with provenance
         run: npm publish --provenance --access public
+      - name: Smoke test published package
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          smoke_dir="$(mktemp -d)"
+          cd "$smoke_dir"
+          npm init -y >/dev/null
+          npm install --ignore-scripts "kommo-mcp-server@$version"
+          node --input-type=module -e "await import('kommo-mcp-server')"
+          test -x node_modules/.bin/kommo-mcp-server
 
+  publish-container:
+    name: Publish container image
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Build and publish Docker image with SBOM and provenance
+      - name: Build and publish with SBOM and provenance
         run: |
           image="ghcr.io/${GITHUB_REPOSITORY,,}"
           version="${GITHUB_REF_NAME#v}"
           minor="${version%.*}"
-          docker buildx create --use
           docker buildx build \
             --push \
             --provenance=true \
@@ -54,8 +99,31 @@ jobs:
             --tag "$image:$minor" \
             --tag "$image:latest" \
             .
+      - name: Smoke test published image
+        run: |
+          image="ghcr.io/${GITHUB_REPOSITORY,,}:${GITHUB_REF_NAME#v}"
+          container="$(docker run -d \
+            -e KOMMO_BASE_URL=https://example.kommo.com \
+            -e KOMMO_ACCESS_TOKEN=release-smoke-test \
+            -e MCP_AUTH_TOKEN=release-smoke-test \
+            "$image")"
+          trap 'docker logs "$container"; docker rm -f "$container"' EXIT
+          for attempt in {1..15}; do
+            status="$(docker inspect --format '{{.State.Health.Status}}' "$container")"
+            test "$status" = healthy && exit 0
+            test "$status" = unhealthy && exit 1
+            sleep 2
+          done
+          exit 1
 
-      - name: Create GitHub release notes
-        run: gh release view "$GITHUB_REF_NAME" || gh release create "$GITHUB_REF_NAME" --generate-notes --title "Kommo MCP Server $GITHUB_REF_NAME"
+  create-release:
+    name: Create GitHub release
+    needs: [publish-npm, publish-container]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release notes
+        run: gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" || gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --generate-notes --title "Kommo MCP Server $GITHUB_REF_NAME"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 - Compatibilidade stateless com clientes MCP da família 2025.
 - Limitador coordenado de requisições ao Kommo por processo.
 - Cobertura do código de produção medida no CI com pisos explícitos para
-  linhas, branches e funções, compatíveis com Node 20 e 22.
+  linhas, branches e funções, compatíveis com Node 22 e 24.
+- Análise CodeQL semanal e em Pull Requests.
+- Smoke tests do pacote npm e da imagem GHCR após a publicação.
 
 ### Modificado
 
@@ -52,6 +54,10 @@ e este projeto segue [Versionamento Semântico](https://semver.org/lang/pt-BR/).
   documentados de leads, pipelines, usuários e tarefas.
 - Payloads de iniciar e parar Salesbot corrigidos conforme a API v4 oficial.
 - Falhas de paginação agora interrompem a operação em vez de retornar totais parciais.
+- Tipos de Node alinhados ao menor runtime suportado e requisitos de desenvolvimento documentados.
+- Workflow de release dividido em validação, npm, GHCR e criação da GitHub Release.
+- Timeout e número de retentativas agora rejeitam configurações inválidas.
+- Runtime mínimo atualizado para Node 22.13; a imagem oficial passa a usar Node 24 LTS.
 
 ### Removido
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ cd Kommo-MCP
 
 ### 2. Instalação
 
-Requer **Node.js 20+**.
+Requer **Node.js 22.13+**. A CI valida as linhas Node 22 e 24.
 
 ```bash
 npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM node:20-slim AS builder
+FROM node:24-slim AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY tsconfig.json ./
 RUN npm run build
 
 # Production stage
-FROM node:20-slim AS production
+FROM node:24-slim AS production
 
 ENV NODE_ENV=production \
     PORT=3001 \

--- a/README.en.md
+++ b/README.en.md
@@ -9,19 +9,25 @@ protocol family, Streamable HTTP and local stdio.
 
 ## Local installation
 
-Requires Node.js 20 or newer.
+The npm package has not been published yet. Until the v3 release, install it
+from source. Node.js 22.13 or newer is required.
 
 ```bash
-npm install -g kommo-mcp-server@3.0.0
+git clone https://github.com/Miguelgbastos/Kommo-MCP.git
+cd Kommo-MCP
+npm ci
+npm run build
 ```
 
-Configure your MCP client to run:
+Configure your MCP client to run the compiled stdio entrypoint, replacing the
+path below with the absolute path to your clone:
 
 ```json
 {
   "mcpServers": {
     "kommo": {
-      "command": "kommo-mcp-server",
+      "command": "node",
+      "args": ["/absolute/path/to/Kommo-MCP/dist/stdio.js"],
       "env": {
         "KOMMO_BASE_URL": "https://your-account.kommo.com",
         "KOMMO_ACCESS_TOKEN": "your-token"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/Miguelgbastos/Kommo-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/Miguelgbastos/Kommo-MCP/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](package.json)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.13-brightgreen.svg)](package.json)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
@@ -58,7 +58,7 @@ Desktop, etc.).
 
 ## Pré-requisitos
 
-- Node.js **20+**
+- Node.js **22.13+**
 - Docker (opcional)
 - Token de acesso do Kommo (integração privada ou OAuth2) —
   ver [documentação do Kommo](https://pt-developers.kommo.com/docs/kommo-para-desenvolvedores)
@@ -148,14 +148,15 @@ docker run -d -p 3001:3001 \
 
 ### Cursor
 
-Para execução local por `stdio`, adicione ao `~/.cursor/mcp.json`:
+O pacote npm ainda não foi publicado. Até a release v3, compile o projeto e
+adicione ao `~/.cursor/mcp.json` o caminho absoluto do arquivo gerado:
 
 ```json
 {
   "mcpServers": {
     "kommo": {
-      "command": "npx",
-      "args": ["-y", "kommo-mcp-server@3.0.0"],
+      "command": "node",
+      "args": ["/caminho/absoluto/Kommo-MCP/dist/stdio.js"],
       "env": {
         "KOMMO_BASE_URL": "https://seu-dominio.kommo.com",
         "KOMMO_ACCESS_TOKEN": "seu-token-aqui"
@@ -335,7 +336,7 @@ Clientes modernos podem fixar `2026-07-28` conforme o exemplo acima.
 - **Docker `HEALTHCHECK` falha** — a imagem usa `node --eval` para o
   healthcheck, verifique se a porta interna corresponde a `PORT`.
 - **Erros de build TypeScript** — rode `npm run typecheck` para ver mensagens
-  detalhadas. Requer Node.js 20+.
+  detalhadas. Requer Node.js 22.13+.
 
 ## Documentação
 
@@ -353,14 +354,14 @@ Clientes modernos podem fixar `2026-07-28` conforme o exemplo acima.
 
 ## Compatibilidade e suporte
 
-| Componente     | Suporte atual                          |
-| -------------- | -------------------------------------- |
-| Node.js        | 20 e 22                                |
-| Protocolo MCP  | `2026-07-28` e família 2025 stateless  |
-| Transporte     | Streamable HTTP e stdio oficiais       |
-| Cursor         | stdio local ou HTTP                    |
-| Claude Desktop | stdio local ou conector remoto         |
-| Instalação     | Git, Docker e pacote npm na release v3 |
+| Componente     | Suporte atual                         |
+| -------------- | ------------------------------------- |
+| Node.js        | 22.13+; CI em Node 22 e 24            |
+| Protocolo MCP  | `2026-07-28` e família 2025 stateless |
+| Transporte     | Streamable HTTP e stdio oficiais      |
+| Cursor         | stdio local ou HTTP                   |
+| Claude Desktop | stdio local ou conector remoto        |
+| Instalação     | Git e Docker; npm após a release v3   |
 
 Suporte comunitário ocorre por Issues e Discussions, sem garantia de tempo de
 resposta. Veja as responsabilidades em [MAINTAINERS.md](MAINTAINERS.md).

--- a/env.example
+++ b/env.example
@@ -2,6 +2,7 @@
 KOMMO_BASE_URL=https://seu-dominio.kommo.com
 KOMMO_ACCESS_TOKEN=seu-token-aqui
 KOMMO_TIMEOUT_MS=15000
+# Inteiro entre 0 e 10; use 0 para desativar retentativas de leitura
 KOMMO_MAX_RETRIES=3
 # Limite coordenado por processo; mantenha em no máximo 6 req/s
 KOMMO_REQUESTS_PER_SECOND=6

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@modelcontextprotocol/client": "^2.0.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
-        "@types/node": "^26.2.0",
+        "@types/node": "^22.20.1",
         "@types/supertest": "^7.2.1",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.67.0",
@@ -38,7 +38,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -509,13 +509,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/qs": {
@@ -3379,9 +3379,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/Miguelgbastos/Kommo-MCP#readme",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "files": [
     "dist",
@@ -71,7 +71,7 @@
     "@modelcontextprotocol/client": "^2.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
-    "@types/node": "^26.2.0",
+    "@types/node": "^22.20.1",
     "@types/supertest": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "^8.67.0",
     "@typescript-eslint/parser": "^8.67.0",

--- a/src/http-streamable.ts
+++ b/src/http-streamable.ts
@@ -35,6 +35,18 @@ export function validateRuntimeConfig(env: NodeJS.ProcessEnv = process.env): str
     }
   }
   if (!env.KOMMO_ACCESS_TOKEN) issues.push('KOMMO_ACCESS_TOKEN is required');
+  if (env.KOMMO_TIMEOUT_MS) {
+    const timeoutMs = Number(env.KOMMO_TIMEOUT_MS);
+    if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+      issues.push('KOMMO_TIMEOUT_MS must be a positive integer');
+    }
+  }
+  if (env.KOMMO_MAX_RETRIES) {
+    const maxRetries = Number(env.KOMMO_MAX_RETRIES);
+    if (!Number.isInteger(maxRetries) || maxRetries < 0 || maxRetries > 10) {
+      issues.push('KOMMO_MAX_RETRIES must be an integer between 0 and 10');
+    }
+  }
   if (env.KOMMO_REQUESTS_PER_SECOND) {
     const requestsPerSecond = Number(env.KOMMO_REQUESTS_PER_SECOND);
     if (!Number.isFinite(requestsPerSecond) || requestsPerSecond <= 0 || requestsPerSecond > 6) {
@@ -90,10 +102,10 @@ export function createApp(options: AppOptions = {}) {
     new KommoAPI({
       baseUrl: process.env.KOMMO_BASE_URL || 'https://api-g.kommo.com',
       accessToken: process.env.KOMMO_ACCESS_TOKEN || '',
-      timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS) || 15_000,
-      maxRetries: Number(process.env.KOMMO_MAX_RETRIES) || 3,
+      timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS ?? 15_000),
+      maxRetries: Number(process.env.KOMMO_MAX_RETRIES ?? 3),
       timezone: process.env.KOMMO_TIMEZONE,
-      requestsPerSecond: Number(process.env.KOMMO_REQUESTS_PER_SECOND) || 6,
+      requestsPerSecond: Number(process.env.KOMMO_REQUESTS_PER_SECOND ?? 6),
     });
   const logger = {
     error: (message: string, error?: unknown) => {

--- a/src/kommo-api.ts
+++ b/src/kommo-api.ts
@@ -328,7 +328,14 @@ export class KommoAPI {
     if (config.timezone) assertTimezone(config.timezone);
     this.configuredTimezone = config.timezone;
     const maxRetries = config.maxRetries ?? 3;
+    const timeoutMs = config.timeoutMs ?? 15_000;
     const requestsPerSecond = config.requestsPerSecond ?? 6;
+    if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new Error('timeoutMs must be a positive integer');
+    }
+    if (!Number.isInteger(maxRetries) || maxRetries < 0 || maxRetries > 10) {
+      throw new Error('maxRetries must be an integer between 0 and 10');
+    }
     if (!Number.isFinite(requestsPerSecond) || requestsPerSecond <= 0 || requestsPerSecond > 6) {
       throw new Error('requestsPerSecond must be greater than 0 and at most 6');
     }
@@ -347,7 +354,7 @@ export class KommoAPI {
     rateLimitStates.set(config.baseUrl, this.rateLimitState);
     this.client = axios.create({
       baseURL: config.baseUrl,
-      timeout: config.timeoutMs ?? 15_000,
+      timeout: timeoutMs,
       headers: {
         Authorization: `Bearer ${config.accessToken}`,
         'Content-Type': 'application/json',

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -16,10 +16,10 @@ export function startStdioServer() {
   const kommoAPI = new KommoAPI({
     baseUrl: process.env.KOMMO_BASE_URL!,
     accessToken: process.env.KOMMO_ACCESS_TOKEN!,
-    timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS) || 15_000,
-    maxRetries: Number(process.env.KOMMO_MAX_RETRIES) || 3,
+    timeoutMs: Number(process.env.KOMMO_TIMEOUT_MS ?? 15_000),
+    maxRetries: Number(process.env.KOMMO_MAX_RETRIES ?? 3),
     timezone: process.env.KOMMO_TIMEZONE,
-    requestsPerSecond: Number(process.env.KOMMO_REQUESTS_PER_SECOND) || 6,
+    requestsPerSecond: Number(process.env.KOMMO_REQUESTS_PER_SECOND ?? 6),
   });
 
   return serveStdio(() => createKommoMcpServer(kommoAPI), {

--- a/test/http-streamable.test.mjs
+++ b/test/http-streamable.test.mjs
@@ -53,6 +53,20 @@ test('runtime configuration requires a valid HTTPS URL and token', () => {
   );
 });
 
+test('runtime configuration rejects unsafe numeric settings and accepts zero retries', () => {
+  const required = {
+    KOMMO_BASE_URL: 'https://example.kommo.com',
+    KOMMO_ACCESS_TOKEN: 'x',
+  };
+  assert.deepEqual(validateRuntimeConfig({ ...required, KOMMO_TIMEOUT_MS: '-1' }), [
+    'KOMMO_TIMEOUT_MS must be a positive integer',
+  ]);
+  assert.deepEqual(validateRuntimeConfig({ ...required, KOMMO_MAX_RETRIES: '11' }), [
+    'KOMMO_MAX_RETRIES must be an integer between 0 and 10',
+  ]);
+  assert.deepEqual(validateRuntimeConfig({ ...required, KOMMO_MAX_RETRIES: '0' }), []);
+});
+
 test('serves 2025-era clients through stateless compatibility', async () => {
   const app = createApp({ logLevel: 'silent' });
   const response = await request(app)

--- a/test/kommo-api.test.mjs
+++ b/test/kommo-api.test.mjs
@@ -3,6 +3,13 @@ import assert from 'node:assert/strict';
 import http from 'node:http';
 import { KommoAPI, parseRetryAfter } from '../dist/kommo-api.js';
 
+test('rejects unsafe retry and timeout configuration', () => {
+  const baseConfig = { baseUrl: 'https://example.kommo.com', accessToken: 'token' };
+  assert.throws(() => new KommoAPI({ ...baseConfig, timeoutMs: 0 }), /positive integer/);
+  assert.throws(() => new KommoAPI({ ...baseConfig, maxRetries: -1 }), /between 0 and 10/);
+  assert.doesNotThrow(() => new KommoAPI({ ...baseConfig, maxRetries: 0 }));
+});
+
 async function withServer(context, handler) {
   const server = http.createServer(handler);
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));


### PR DESCRIPTION
## Resumo

- atualiza o runtime suportado para Node 22.13+ e a CI para Node 22/24
- usa Node 24 LTS na imagem e alinha os tipos ao menor runtime suportado
- corrige a documentação enquanto o pacote npm ainda não está publicado
- valida timeout e retentativas, incluindo suporte real a zero retentativas
- separa validação, npm, GHCR e GitHub Release, com smoke tests pós-publicação
- adiciona CodeQL em PRs, main e execução semanal

## Validação local

- npm ci
- lint, typecheck e format:check
- 23 testes
- cobertura
- npm audit completo sem vulnerabilidades
- npm pack --dry-run
- sintaxe YAML dos workflows

## Fora deste PR

A credencial histórica precisa ser revogada no Kommo antes de qualquer reescrita destrutiva do histórico Git. A validação manual da issue #4 também permanece como gate da v3.